### PR TITLE
Updated library to allow for ESP32 based devices to use Serial communication to communicate

### DIFF
--- a/src/ArduinoHardware.h
+++ b/src/ArduinoHardware.h
@@ -60,6 +60,10 @@
 #elif defined(STM32F4xx)
   #include <HardwareSerial.h> 
   #define SERIAL_CLASS USBSerial
+#elif defined(ESP32) and defined(ARDUINO_USB_CDC_ON_BOOT) and !(defined(ROSSERIAL_ARDUINO_TCP))
+  #include <HardwareSerial.h>
+  #include <HWCDC.h>
+  #define SERIAL_CLASS HWCDC
 #else 
   #include <HardwareSerial.h>  // Arduino AVR
   #define SERIAL_CLASS HardwareSerial

--- a/src/actionlib/TestAction.h
+++ b/src/actionlib/TestAction.h
@@ -49,8 +49,8 @@ namespace actionlib
      return offset;
     }
 
-    virtual const char * getType(const char * type_msg) override { strcpy_P(type_msg, (char *)actionlib_TestAction_type);return type_msg; };
-    virtual const char * getMD5(const char * md5_msg) override { strcpy_P(md5_msg, (char *)actionlib_TestAction_md5);return md5_msg; };
+    virtual const char * getType(const char * type_msg) override { strcpy_P((char *)type_msg, (char *)actionlib_TestAction_type);return type_msg; };
+    virtual const char * getMD5(const char * md5_msg) override { strcpy_P((char *)md5_msg, (char *)actionlib_TestAction_md5);return md5_msg; };
 
   };
 

--- a/src/actionlib/TestActionFeedback.h
+++ b/src/actionlib/TestActionFeedback.h
@@ -49,8 +49,8 @@ namespace actionlib
      return offset;
     }
 
-    virtual const char * getType(const char * type_msg) override { strcpy_P(type_msg, (char *)actionlib_TestActionFeedback_type);return type_msg; };
-    virtual const char * getMD5(const char * md5_msg) override { strcpy_P(md5_msg, (char *)actionlib_TestActionFeedback_md5);return md5_msg; };
+    virtual const char * getType(const char * type_msg) override { strcpy_P((char *)type_msg, (char *)actionlib_TestActionFeedback_type);return type_msg; };
+    virtual const char * getMD5(const char * md5_msg) override { strcpy_P((char *)md5_msg, (char *)actionlib_TestActionFeedback_md5);return md5_msg; };
 
   };
 

--- a/src/actionlib/TestActionGoal.h
+++ b/src/actionlib/TestActionGoal.h
@@ -49,8 +49,8 @@ namespace actionlib
      return offset;
     }
 
-    virtual const char * getType(const char * type_msg) override { strcpy_P(type_msg, (char *)actionlib_TestActionGoal_type);return type_msg; };
-    virtual const char * getMD5(const char * md5_msg) override { strcpy_P(md5_msg, (char *)actionlib_TestActionGoal_md5);return md5_msg; };
+    virtual const char * getType(const char * type_msg) override { strcpy_P((char *)type_msg, (char *)actionlib_TestActionGoal_type);return type_msg; };
+    virtual const char * getMD5(const char * md5_msg) override { strcpy_P((char *)md5_msg, (char *)actionlib_TestActionGoal_md5);return md5_msg; };
 
   };
 

--- a/src/actionlib/TestActionResult.h
+++ b/src/actionlib/TestActionResult.h
@@ -49,8 +49,8 @@ namespace actionlib
      return offset;
     }
 
-    virtual const char * getType(const char * type_msg) override { strcpy_P(type_msg, (char *)actionlib_TestActionResult_type);return type_msg; };
-    virtual const char * getMD5(const char * md5_msg) override { strcpy_P(md5_msg, (char *)actionlib_TestActionResult_md5);return md5_msg; };
+    virtual const char * getType(const char * type_msg) override { strcpy_P((char *)type_msg, (char *)actionlib_TestActionResult_type);return type_msg; };
+    virtual const char * getMD5(const char * md5_msg) override { strcpy_P((char *)md5_msg, (char *)actionlib_TestActionResult_md5);return md5_msg; };
 
   };
 

--- a/src/actionlib/TestFeedback.h
+++ b/src/actionlib/TestFeedback.h
@@ -55,8 +55,8 @@ namespace actionlib
      return offset;
     }
 
-    virtual const char * getType(const char * type_msg) override { strcpy_P(type_msg, (char *)actionlib_TestFeedback_type);return type_msg; };
-    virtual const char * getMD5(const char * md5_msg) override { strcpy_P(md5_msg, (char *)actionlib_TestFeedback_md5);return md5_msg; };
+    virtual const char * getType(const char * type_msg) override { strcpy_P((char *)type_msg, (char *)actionlib_TestFeedback_type);return type_msg; };
+    virtual const char * getMD5(const char * md5_msg) override { strcpy_P((char *)md5_msg, (char *)actionlib_TestFeedback_md5);return md5_msg; };
 
   };
 

--- a/src/actionlib/TestGoal.h
+++ b/src/actionlib/TestGoal.h
@@ -55,8 +55,8 @@ namespace actionlib
      return offset;
     }
 
-    virtual const char * getType(const char * type_msg) override { strcpy_P(type_msg, (char *)actionlib_TestGoal_type);return type_msg; };
-    virtual const char * getMD5(const char * md5_msg) override { strcpy_P(md5_msg, (char *)actionlib_TestGoal_md5);return md5_msg; };
+    virtual const char * getType(const char * type_msg) override { strcpy_P((char *)type_msg, (char *)actionlib_TestGoal_type);return type_msg; };
+    virtual const char * getMD5(const char * md5_msg) override { strcpy_P((char *)md5_msg, (char *)actionlib_TestGoal_md5);return md5_msg; };
 
   };
 

--- a/src/actionlib/TestRequestAction.h
+++ b/src/actionlib/TestRequestAction.h
@@ -49,8 +49,8 @@ namespace actionlib
      return offset;
     }
 
-    virtual const char * getType(const char * type_msg) override { strcpy_P(type_msg, (char *)actionlib_TestRequestAction_type);return type_msg; };
-    virtual const char * getMD5(const char * md5_msg) override { strcpy_P(md5_msg, (char *)actionlib_TestRequestAction_md5);return md5_msg; };
+    virtual const char * getType(const char * type_msg) override { strcpy_P((char *)type_msg, (char *)actionlib_TestRequestAction_type);return type_msg; };
+    virtual const char * getMD5(const char * md5_msg) override { strcpy_P((char *)md5_msg, (char *)actionlib_TestRequestAction_md5);return md5_msg; };
 
   };
 

--- a/src/actionlib/TestRequestActionFeedback.h
+++ b/src/actionlib/TestRequestActionFeedback.h
@@ -49,8 +49,8 @@ namespace actionlib
      return offset;
     }
 
-    virtual const char * getType(const char * type_msg) override { strcpy_P(type_msg, (char *)actionlib_TestRequestActionFeedback_type);return type_msg; };
-    virtual const char * getMD5(const char * md5_msg) override { strcpy_P(md5_msg, (char *)actionlib_TestRequestActionFeedback_md5);return md5_msg; };
+    virtual const char * getType(const char * type_msg) override { strcpy_P((char *)type_msg, (char *)actionlib_TestRequestActionFeedback_type);return type_msg; };
+    virtual const char * getMD5(const char * md5_msg) override { strcpy_P((char *)md5_msg, (char *)actionlib_TestRequestActionFeedback_md5);return md5_msg; };
 
   };
 

--- a/src/actionlib/TestRequestActionGoal.h
+++ b/src/actionlib/TestRequestActionGoal.h
@@ -49,8 +49,8 @@ namespace actionlib
      return offset;
     }
 
-    virtual const char * getType(const char * type_msg) override { strcpy_P(type_msg, (char *)actionlib_TestRequestActionGoal_type);return type_msg; };
-    virtual const char * getMD5(const char * md5_msg) override { strcpy_P(md5_msg, (char *)actionlib_TestRequestActionGoal_md5);return md5_msg; };
+    virtual const char * getType(const char * type_msg) override { strcpy_P((char *)type_msg, (char *)actionlib_TestRequestActionGoal_type);return type_msg; };
+    virtual const char * getMD5(const char * md5_msg) override { strcpy_P((char *)md5_msg, (char *)actionlib_TestRequestActionGoal_md5);return md5_msg; };
 
   };
 

--- a/src/actionlib/TestRequestActionResult.h
+++ b/src/actionlib/TestRequestActionResult.h
@@ -49,8 +49,8 @@ namespace actionlib
      return offset;
     }
 
-    virtual const char * getType(const char * type_msg) override { strcpy_P(type_msg, (char *)actionlib_TestRequestActionResult_type);return type_msg; };
-    virtual const char * getMD5(const char * md5_msg) override { strcpy_P(md5_msg, (char *)actionlib_TestRequestActionResult_md5);return md5_msg; };
+    virtual const char * getType(const char * type_msg) override { strcpy_P((char *)type_msg, (char *)actionlib_TestRequestActionResult_type);return type_msg; };
+    virtual const char * getMD5(const char * md5_msg) override { strcpy_P((char *)md5_msg, (char *)actionlib_TestRequestActionResult_md5);return md5_msg; };
 
   };
 

--- a/src/actionlib/TestRequestFeedback.h
+++ b/src/actionlib/TestRequestFeedback.h
@@ -31,8 +31,8 @@ namespace actionlib
      return offset;
     }
 
-    virtual const char * getType(const char * type_msg) override { strcpy_P(type_msg, (char *)actionlib_TestRequestFeedback_type);return type_msg; };
-    virtual const char * getMD5(const char * md5_msg) override { strcpy_P(md5_msg, (char *)actionlib_TestRequestFeedback_md5);return md5_msg; };
+    virtual const char * getType(const char * type_msg) override { strcpy_P((char *)type_msg, (char *)actionlib_TestRequestFeedback_type);return type_msg; };
+    virtual const char * getMD5(const char * md5_msg) override { strcpy_P((char *)md5_msg, (char *)actionlib_TestRequestFeedback_md5);return md5_msg; };
 
   };
 

--- a/src/actionlib/TestRequestGoal.h
+++ b/src/actionlib/TestRequestGoal.h
@@ -208,8 +208,8 @@ namespace actionlib
      return offset;
     }
 
-    virtual const char * getType(const char * type_msg) override { strcpy_P(type_msg, (char *)actionlib_TestRequestGoal_type);return type_msg; };
-    virtual const char * getMD5(const char * md5_msg) override { strcpy_P(md5_msg, (char *)actionlib_TestRequestGoal_md5);return md5_msg; };
+    virtual const char * getType(const char * type_msg) override { strcpy_P((char *)type_msg, (char *)actionlib_TestRequestGoal_type);return type_msg; };
+    virtual const char * getMD5(const char * md5_msg) override { strcpy_P((char *)md5_msg, (char *)actionlib_TestRequestGoal_md5);return md5_msg; };
 
   };
 

--- a/src/actionlib/TestRequestResult.h
+++ b/src/actionlib/TestRequestResult.h
@@ -73,8 +73,8 @@ namespace actionlib
      return offset;
     }
 
-    virtual const char * getType(const char * type_msg) override { strcpy_P(type_msg, (char *)actionlib_TestRequestResult_type);return type_msg; };
-    virtual const char * getMD5(const char * md5_msg) override { strcpy_P(md5_msg, (char *)actionlib_TestRequestResult_md5);return md5_msg; };
+    virtual const char * getType(const char * type_msg) override { strcpy_P((char *)type_msg, (char *)actionlib_TestRequestResult_type);return type_msg; };
+    virtual const char * getMD5(const char * md5_msg) override { strcpy_P((char *)md5_msg, (char *)actionlib_TestRequestResult_md5);return md5_msg; };
 
   };
 

--- a/src/actionlib/TestResult.h
+++ b/src/actionlib/TestResult.h
@@ -55,8 +55,8 @@ namespace actionlib
      return offset;
     }
 
-    virtual const char * getType(const char * type_msg) override { strcpy_P(type_msg, (char *)actionlib_TestResult_type);return type_msg; };
-    virtual const char * getMD5(const char * md5_msg) override { strcpy_P(md5_msg, (char *)actionlib_TestResult_md5);return md5_msg; };
+    virtual const char * getType(const char * type_msg) override { strcpy_P((char *)type_msg, (char *)actionlib_TestResult_type);return type_msg; };
+    virtual const char * getMD5(const char * md5_msg) override { strcpy_P((char *)md5_msg, (char *)actionlib_TestResult_md5);return md5_msg; };
 
   };
 

--- a/src/actionlib/TwoIntsAction.h
+++ b/src/actionlib/TwoIntsAction.h
@@ -49,8 +49,8 @@ namespace actionlib
      return offset;
     }
 
-    virtual const char * getType(const char * type_msg) override { strcpy_P(type_msg, (char *)actionlib_TwoIntsAction_type);return type_msg; };
-    virtual const char * getMD5(const char * md5_msg) override { strcpy_P(md5_msg, (char *)actionlib_TwoIntsAction_md5);return md5_msg; };
+    virtual const char * getType(const char * type_msg) override { strcpy_P((char *)type_msg, (char *)actionlib_TwoIntsAction_type);return type_msg; };
+    virtual const char * getMD5(const char * md5_msg) override { strcpy_P((char *)md5_msg, (char *)actionlib_TwoIntsAction_md5);return md5_msg; };
 
   };
 

--- a/src/actionlib/TwoIntsActionFeedback.h
+++ b/src/actionlib/TwoIntsActionFeedback.h
@@ -49,8 +49,8 @@ namespace actionlib
      return offset;
     }
 
-    virtual const char * getType(const char * type_msg) override { strcpy_P(type_msg, (char *)actionlib_TwoIntsActionFeedback_type);return type_msg; };
-    virtual const char * getMD5(const char * md5_msg) override { strcpy_P(md5_msg, (char *)actionlib_TwoIntsActionFeedback_md5);return md5_msg; };
+    virtual const char * getType(const char * type_msg) override { strcpy_P((char *)type_msg, (char *)actionlib_TwoIntsActionFeedback_type);return type_msg; };
+    virtual const char * getMD5(const char * md5_msg) override { strcpy_P((char *)md5_msg, (char *)actionlib_TwoIntsActionFeedback_md5);return md5_msg; };
 
   };
 

--- a/src/actionlib/TwoIntsActionGoal.h
+++ b/src/actionlib/TwoIntsActionGoal.h
@@ -49,8 +49,8 @@ namespace actionlib
      return offset;
     }
 
-    virtual const char * getType(const char * type_msg) override { strcpy_P(type_msg, (char *)actionlib_TwoIntsActionGoal_type);return type_msg; };
-    virtual const char * getMD5(const char * md5_msg) override { strcpy_P(md5_msg, (char *)actionlib_TwoIntsActionGoal_md5);return md5_msg; };
+    virtual const char * getType(const char * type_msg) override { strcpy_P((char *)type_msg, (char *)actionlib_TwoIntsActionGoal_type);return type_msg; };
+    virtual const char * getMD5(const char * md5_msg) override { strcpy_P((char *)md5_msg, (char *)actionlib_TwoIntsActionGoal_md5);return md5_msg; };
 
   };
 

--- a/src/actionlib/TwoIntsActionResult.h
+++ b/src/actionlib/TwoIntsActionResult.h
@@ -49,8 +49,8 @@ namespace actionlib
      return offset;
     }
 
-    virtual const char * getType(const char * type_msg) override { strcpy_P(type_msg, (char *)actionlib_TwoIntsActionResult_type);return type_msg; };
-    virtual const char * getMD5(const char * md5_msg) override { strcpy_P(md5_msg, (char *)actionlib_TwoIntsActionResult_md5);return md5_msg; };
+    virtual const char * getType(const char * type_msg) override { strcpy_P((char *)type_msg, (char *)actionlib_TwoIntsActionResult_type);return type_msg; };
+    virtual const char * getMD5(const char * md5_msg) override { strcpy_P((char *)md5_msg, (char *)actionlib_TwoIntsActionResult_md5);return md5_msg; };
 
   };
 

--- a/src/actionlib/TwoIntsFeedback.h
+++ b/src/actionlib/TwoIntsFeedback.h
@@ -31,8 +31,8 @@ namespace actionlib
      return offset;
     }
 
-    virtual const char * getType(const char * type_msg) override { strcpy_P(type_msg, (char *)actionlib_TwoIntsFeedback_type);return type_msg; };
-    virtual const char * getMD5(const char * md5_msg) override { strcpy_P(md5_msg, (char *)actionlib_TwoIntsFeedback_md5);return md5_msg; };
+    virtual const char * getType(const char * type_msg) override { strcpy_P((char *)type_msg, (char *)actionlib_TwoIntsFeedback_type);return type_msg; };
+    virtual const char * getMD5(const char * md5_msg) override { strcpy_P((char *)md5_msg, (char *)actionlib_TwoIntsFeedback_md5);return md5_msg; };
 
   };
 

--- a/src/actionlib/TwoIntsGoal.h
+++ b/src/actionlib/TwoIntsGoal.h
@@ -95,8 +95,8 @@ namespace actionlib
      return offset;
     }
 
-    virtual const char * getType(const char * type_msg) override { strcpy_P(type_msg, (char *)actionlib_TwoIntsGoal_type);return type_msg; };
-    virtual const char * getMD5(const char * md5_msg) override { strcpy_P(md5_msg, (char *)actionlib_TwoIntsGoal_md5);return md5_msg; };
+    virtual const char * getType(const char * type_msg) override { strcpy_P((char *)type_msg, (char *)actionlib_TwoIntsGoal_type);return type_msg; };
+    virtual const char * getMD5(const char * md5_msg) override { strcpy_P((char *)md5_msg, (char *)actionlib_TwoIntsGoal_md5);return md5_msg; };
 
   };
 

--- a/src/actionlib/TwoIntsResult.h
+++ b/src/actionlib/TwoIntsResult.h
@@ -63,8 +63,8 @@ namespace actionlib
      return offset;
     }
 
-    virtual const char * getType(const char * type_msg) override { strcpy_P(type_msg, (char *)actionlib_TwoIntsResult_type);return type_msg; };
-    virtual const char * getMD5(const char * md5_msg) override { strcpy_P(md5_msg, (char *)actionlib_TwoIntsResult_md5);return md5_msg; };
+    virtual const char * getType(const char * type_msg) override { strcpy_P((char *)type_msg, (char *)actionlib_TwoIntsResult_type);return type_msg; };
+    virtual const char * getMD5(const char * md5_msg) override { strcpy_P((char *)md5_msg, (char *)actionlib_TwoIntsResult_md5);return md5_msg; };
 
   };
 

--- a/src/actionlib_msgs/GoalID.h
+++ b/src/actionlib_msgs/GoalID.h
@@ -72,8 +72,8 @@ namespace actionlib_msgs
      return offset;
     }
 
-    virtual const char * getType(const char * type_msg) override { strcpy_P(type_msg, (char *)actionlib_msgs_GoalID_type);return type_msg; };
-    virtual const char * getMD5(const char * md5_msg) override { strcpy_P(md5_msg, (char *)actionlib_msgs_GoalID_md5);return md5_msg; };
+    virtual const char * getType(const char * type_msg) override { strcpy_P((char *)type_msg, (char *)actionlib_msgs_GoalID_type);return type_msg; };
+    virtual const char * getMD5(const char * md5_msg) override { strcpy_P((char *)md5_msg, (char *)actionlib_msgs_GoalID_md5);return md5_msg; };
 
   };
 

--- a/src/actionlib_msgs/GoalStatus.h
+++ b/src/actionlib_msgs/GoalStatus.h
@@ -71,8 +71,8 @@ namespace actionlib_msgs
      return offset;
     }
 
-    virtual const char * getType(const char * type_msg) override { strcpy_P(type_msg, (char *)actionlib_msgs_GoalStatus_type);return type_msg; };
-    virtual const char * getMD5(const char * md5_msg) override { strcpy_P(md5_msg, (char *)actionlib_msgs_GoalStatus_md5);return md5_msg; };
+    virtual const char * getType(const char * type_msg) override { strcpy_P((char *)type_msg, (char *)actionlib_msgs_GoalStatus_type);return type_msg; };
+    virtual const char * getMD5(const char * md5_msg) override { strcpy_P((char *)md5_msg, (char *)actionlib_msgs_GoalStatus_md5);return md5_msg; };
 
   };
 

--- a/src/actionlib_msgs/GoalStatusArray.h
+++ b/src/actionlib_msgs/GoalStatusArray.h
@@ -63,8 +63,8 @@ namespace actionlib_msgs
      return offset;
     }
 
-    virtual const char * getType(const char * type_msg) override { strcpy_P(type_msg, (char *)actionlib_msgs_GoalStatusArray_type);return type_msg; };
-    virtual const char * getMD5(const char * md5_msg) override { strcpy_P(md5_msg, (char *)actionlib_msgs_GoalStatusArray_md5);return md5_msg; };
+    virtual const char * getType(const char * type_msg) override { strcpy_P((char *)type_msg, (char *)actionlib_msgs_GoalStatusArray_type);return type_msg; };
+    virtual const char * getMD5(const char * md5_msg) override { strcpy_P((char *)md5_msg, (char *)actionlib_msgs_GoalStatusArray_md5);return md5_msg; };
 
   };
 

--- a/src/bond/Constants.h
+++ b/src/bond/Constants.h
@@ -37,8 +37,8 @@ namespace bond
      return offset;
     }
 
-    virtual const char * getType(const char * type_msg) override { strcpy_P(type_msg, (char *)bond_Constants_type);return type_msg; };
-    virtual const char * getMD5(const char * md5_msg) override { strcpy_P(md5_msg, (char *)bond_Constants_md5);return md5_msg; };
+    virtual const char * getType(const char * type_msg) override { strcpy_P((char *)type_msg, (char *)bond_Constants_type);return type_msg; };
+    virtual const char * getMD5(const char * md5_msg) override { strcpy_P((char *)md5_msg, (char *)bond_Constants_md5);return md5_msg; };
 
   };
 

--- a/src/bond/Status.h
+++ b/src/bond/Status.h
@@ -137,8 +137,8 @@ namespace bond
      return offset;
     }
 
-    virtual const char * getType(const char * type_msg) override { strcpy_P(type_msg, (char *)bond_Status_type);return type_msg; };
-    virtual const char * getMD5(const char * md5_msg) override { strcpy_P(md5_msg, (char *)bond_Status_md5);return md5_msg; };
+    virtual const char * getType(const char * type_msg) override { strcpy_P((char *)type_msg, (char *)bond_Status_type);return type_msg; };
+    virtual const char * getMD5(const char * md5_msg) override { strcpy_P((char *)md5_msg, (char *)bond_Status_md5);return md5_msg; };
 
   };
 

--- a/src/diagnostic_msgs/AddDiagnostics.h
+++ b/src/diagnostic_msgs/AddDiagnostics.h
@@ -49,8 +49,8 @@ static const char ADDDIAGNOSTICS[] PROGMEM= "diagnostic_msgs/AddDiagnostics";
      return offset;
     }
 
-    virtual const char * getType(const char * type_msg) override { strcpy_P(type_msg, (char *)ADDDIAGNOSTICS);return type_msg; };
-    virtual const char * getMD5(const char * md5_msg) override { strcpy_P(md5_msg, (char *)diagnostic_msgs_AddDiagnosticsRequest_md5);return md5_msg; };
+    virtual const char * getType(const char * type_msg) override { strcpy_P((char *)type_msg, (char *)ADDDIAGNOSTICS);return type_msg; };
+    virtual const char * getMD5(const char * md5_msg) override { strcpy_P((char *)md5_msg, (char *)diagnostic_msgs_AddDiagnosticsRequest_md5);return md5_msg; };
 
   };
 
@@ -111,8 +111,8 @@ static const char ADDDIAGNOSTICS[] PROGMEM= "diagnostic_msgs/AddDiagnostics";
      return offset;
     }
 
-    virtual const char * getType(const char * type_msg) override { strcpy_P(type_msg, (char *)ADDDIAGNOSTICS);return type_msg; };
-    virtual const char * getMD5(const char * md5_msg) override { strcpy_P(md5_msg, (char *)diagnostic_msgs_AddDiagnosticsResponse_md5);return md5_msg; };
+    virtual const char * getType(const char * type_msg) override { strcpy_P((char *)type_msg, (char *)ADDDIAGNOSTICS);return type_msg; };
+    virtual const char * getMD5(const char * md5_msg) override { strcpy_P((char *)md5_msg, (char *)diagnostic_msgs_AddDiagnosticsResponse_md5);return md5_msg; };
 
   };
 

--- a/src/diagnostic_msgs/DiagnosticArray.h
+++ b/src/diagnostic_msgs/DiagnosticArray.h
@@ -63,8 +63,8 @@ namespace diagnostic_msgs
      return offset;
     }
 
-    virtual const char * getType(const char * type_msg) override { strcpy_P(type_msg, (char *)diagnostic_msgs_DiagnosticArray_type);return type_msg; };
-    virtual const char * getMD5(const char * md5_msg) override { strcpy_P(md5_msg, (char *)diagnostic_msgs_DiagnosticArray_md5);return md5_msg; };
+    virtual const char * getType(const char * type_msg) override { strcpy_P((char *)type_msg, (char *)diagnostic_msgs_DiagnosticArray_type);return type_msg; };
+    virtual const char * getMD5(const char * md5_msg) override { strcpy_P((char *)md5_msg, (char *)diagnostic_msgs_DiagnosticArray_md5);return md5_msg; };
 
   };
 

--- a/src/diagnostic_msgs/DiagnosticStatus.h
+++ b/src/diagnostic_msgs/DiagnosticStatus.h
@@ -130,8 +130,8 @@ namespace diagnostic_msgs
      return offset;
     }
 
-    virtual const char * getType(const char * type_msg) override { strcpy_P(type_msg, (char *)diagnostic_msgs_DiagnosticStatus_type);return type_msg; };
-    virtual const char * getMD5(const char * md5_msg) override { strcpy_P(md5_msg, (char *)diagnostic_msgs_DiagnosticStatus_md5);return md5_msg; };
+    virtual const char * getType(const char * type_msg) override { strcpy_P((char *)type_msg, (char *)diagnostic_msgs_DiagnosticStatus_type);return type_msg; };
+    virtual const char * getMD5(const char * md5_msg) override { strcpy_P((char *)md5_msg, (char *)diagnostic_msgs_DiagnosticStatus_md5);return md5_msg; };
 
   };
 

--- a/src/diagnostic_msgs/KeyValue.h
+++ b/src/diagnostic_msgs/KeyValue.h
@@ -65,8 +65,8 @@ namespace diagnostic_msgs
      return offset;
     }
 
-    virtual const char * getType(const char * type_msg) override { strcpy_P(type_msg, (char *)diagnostic_msgs_KeyValue_type);return type_msg; };
-    virtual const char * getMD5(const char * md5_msg) override { strcpy_P(md5_msg, (char *)diagnostic_msgs_KeyValue_md5);return md5_msg; };
+    virtual const char * getType(const char * type_msg) override { strcpy_P((char *)type_msg, (char *)diagnostic_msgs_KeyValue_type);return type_msg; };
+    virtual const char * getMD5(const char * md5_msg) override { strcpy_P((char *)md5_msg, (char *)diagnostic_msgs_KeyValue_md5);return md5_msg; };
 
   };
 

--- a/src/diagnostic_msgs/SelfTest.h
+++ b/src/diagnostic_msgs/SelfTest.h
@@ -33,8 +33,8 @@ static const char SELFTEST[] PROGMEM= "diagnostic_msgs/SelfTest";
      return offset;
     }
 
-    virtual const char * getType(const char * type_msg) override { strcpy_P(type_msg, (char *)SELFTEST);return type_msg; };
-    virtual const char * getMD5(const char * md5_msg) override { strcpy_P(md5_msg, (char *)diagnostic_msgs_SelfTestRequest_md5);return md5_msg; };
+    virtual const char * getType(const char * type_msg) override { strcpy_P((char *)type_msg, (char *)SELFTEST);return type_msg; };
+    virtual const char * getMD5(const char * md5_msg) override { strcpy_P((char *)md5_msg, (char *)diagnostic_msgs_SelfTestRequest_md5);return md5_msg; };
 
   };
 
@@ -120,8 +120,8 @@ static const char SELFTEST[] PROGMEM= "diagnostic_msgs/SelfTest";
      return offset;
     }
 
-    virtual const char * getType(const char * type_msg) override { strcpy_P(type_msg, (char *)SELFTEST);return type_msg; };
-    virtual const char * getMD5(const char * md5_msg) override { strcpy_P(md5_msg, (char *)diagnostic_msgs_SelfTestResponse_md5);return md5_msg; };
+    virtual const char * getType(const char * type_msg) override { strcpy_P((char *)type_msg, (char *)SELFTEST);return type_msg; };
+    virtual const char * getMD5(const char * md5_msg) override { strcpy_P((char *)md5_msg, (char *)diagnostic_msgs_SelfTestResponse_md5);return md5_msg; };
 
   };
 

--- a/src/dynamic_reconfigure/BoolParameter.h
+++ b/src/dynamic_reconfigure/BoolParameter.h
@@ -66,8 +66,8 @@ namespace dynamic_reconfigure
      return offset;
     }
 
-    virtual const char * getType(const char * type_msg) override { strcpy_P(type_msg, (char *)dynamic_reconfigure_BoolParameter_type);return type_msg; };
-    virtual const char * getMD5(const char * md5_msg) override { strcpy_P(md5_msg, (char *)dynamic_reconfigure_BoolParameter_md5);return md5_msg; };
+    virtual const char * getType(const char * type_msg) override { strcpy_P((char *)type_msg, (char *)dynamic_reconfigure_BoolParameter_type);return type_msg; };
+    virtual const char * getMD5(const char * md5_msg) override { strcpy_P((char *)md5_msg, (char *)dynamic_reconfigure_BoolParameter_md5);return md5_msg; };
 
   };
 

--- a/src/dynamic_reconfigure/Config.h
+++ b/src/dynamic_reconfigure/Config.h
@@ -161,8 +161,8 @@ namespace dynamic_reconfigure
      return offset;
     }
 
-    virtual const char * getType(const char * type_msg) override { strcpy_P(type_msg, (char *)dynamic_reconfigure_Config_type);return type_msg; };
-    virtual const char * getMD5(const char * md5_msg) override { strcpy_P(md5_msg, (char *)dynamic_reconfigure_Config_md5);return md5_msg; };
+    virtual const char * getType(const char * type_msg) override { strcpy_P((char *)type_msg, (char *)dynamic_reconfigure_Config_type);return type_msg; };
+    virtual const char * getMD5(const char * md5_msg) override { strcpy_P((char *)md5_msg, (char *)dynamic_reconfigure_Config_md5);return md5_msg; };
 
   };
 

--- a/src/dynamic_reconfigure/ConfigDescription.h
+++ b/src/dynamic_reconfigure/ConfigDescription.h
@@ -73,8 +73,8 @@ namespace dynamic_reconfigure
      return offset;
     }
 
-    virtual const char * getType(const char * type_msg) override { strcpy_P(type_msg, (char *)dynamic_reconfigure_ConfigDescription_type);return type_msg; };
-    virtual const char * getMD5(const char * md5_msg) override { strcpy_P(md5_msg, (char *)dynamic_reconfigure_ConfigDescription_md5);return md5_msg; };
+    virtual const char * getType(const char * type_msg) override { strcpy_P((char *)type_msg, (char *)dynamic_reconfigure_ConfigDescription_type);return type_msg; };
+    virtual const char * getMD5(const char * md5_msg) override { strcpy_P((char *)md5_msg, (char *)dynamic_reconfigure_ConfigDescription_md5);return md5_msg; };
 
   };
 

--- a/src/dynamic_reconfigure/DoubleParameter.h
+++ b/src/dynamic_reconfigure/DoubleParameter.h
@@ -53,8 +53,8 @@ namespace dynamic_reconfigure
      return offset;
     }
 
-    virtual const char * getType(const char * type_msg) override { strcpy_P(type_msg, (char *)dynamic_reconfigure_DoubleParameter_type);return type_msg; };
-    virtual const char * getMD5(const char * md5_msg) override { strcpy_P(md5_msg, (char *)dynamic_reconfigure_DoubleParameter_md5);return md5_msg; };
+    virtual const char * getType(const char * type_msg) override { strcpy_P((char *)type_msg, (char *)dynamic_reconfigure_DoubleParameter_type);return type_msg; };
+    virtual const char * getMD5(const char * md5_msg) override { strcpy_P((char *)md5_msg, (char *)dynamic_reconfigure_DoubleParameter_md5);return md5_msg; };
 
   };
 

--- a/src/dynamic_reconfigure/Group.h
+++ b/src/dynamic_reconfigure/Group.h
@@ -139,8 +139,8 @@ namespace dynamic_reconfigure
      return offset;
     }
 
-    virtual const char * getType(const char * type_msg) override { strcpy_P(type_msg, (char *)dynamic_reconfigure_Group_type);return type_msg; };
-    virtual const char * getMD5(const char * md5_msg) override { strcpy_P(md5_msg, (char *)dynamic_reconfigure_Group_md5);return md5_msg; };
+    virtual const char * getType(const char * type_msg) override { strcpy_P((char *)type_msg, (char *)dynamic_reconfigure_Group_type);return type_msg; };
+    virtual const char * getMD5(const char * md5_msg) override { strcpy_P((char *)md5_msg, (char *)dynamic_reconfigure_Group_md5);return md5_msg; };
 
   };
 

--- a/src/dynamic_reconfigure/GroupState.h
+++ b/src/dynamic_reconfigure/GroupState.h
@@ -114,8 +114,8 @@ namespace dynamic_reconfigure
      return offset;
     }
 
-    virtual const char * getType(const char * type_msg) override { strcpy_P(type_msg, (char *)dynamic_reconfigure_GroupState_type);return type_msg; };
-    virtual const char * getMD5(const char * md5_msg) override { strcpy_P(md5_msg, (char *)dynamic_reconfigure_GroupState_md5);return md5_msg; };
+    virtual const char * getType(const char * type_msg) override { strcpy_P((char *)type_msg, (char *)dynamic_reconfigure_GroupState_type);return type_msg; };
+    virtual const char * getMD5(const char * md5_msg) override { strcpy_P((char *)md5_msg, (char *)dynamic_reconfigure_GroupState_md5);return md5_msg; };
 
   };
 

--- a/src/dynamic_reconfigure/IntParameter.h
+++ b/src/dynamic_reconfigure/IntParameter.h
@@ -72,8 +72,8 @@ namespace dynamic_reconfigure
      return offset;
     }
 
-    virtual const char * getType(const char * type_msg) override { strcpy_P(type_msg, (char *)dynamic_reconfigure_IntParameter_type);return type_msg; };
-    virtual const char * getMD5(const char * md5_msg) override { strcpy_P(md5_msg, (char *)dynamic_reconfigure_IntParameter_md5);return md5_msg; };
+    virtual const char * getType(const char * type_msg) override { strcpy_P((char *)type_msg, (char *)dynamic_reconfigure_IntParameter_type);return type_msg; };
+    virtual const char * getMD5(const char * md5_msg) override { strcpy_P((char *)md5_msg, (char *)dynamic_reconfigure_IntParameter_md5);return md5_msg; };
 
   };
 

--- a/src/dynamic_reconfigure/ParamDescription.h
+++ b/src/dynamic_reconfigure/ParamDescription.h
@@ -112,8 +112,8 @@ namespace dynamic_reconfigure
      return offset;
     }
 
-    virtual const char * getType(const char * type_msg) override { strcpy_P(type_msg, (char *)dynamic_reconfigure_ParamDescription_type);return type_msg; };
-    virtual const char * getMD5(const char * md5_msg) override { strcpy_P(md5_msg, (char *)dynamic_reconfigure_ParamDescription_md5);return md5_msg; };
+    virtual const char * getType(const char * type_msg) override { strcpy_P((char *)type_msg, (char *)dynamic_reconfigure_ParamDescription_type);return type_msg; };
+    virtual const char * getMD5(const char * md5_msg) override { strcpy_P((char *)md5_msg, (char *)dynamic_reconfigure_ParamDescription_md5);return md5_msg; };
 
   };
 

--- a/src/dynamic_reconfigure/Reconfigure.h
+++ b/src/dynamic_reconfigure/Reconfigure.h
@@ -38,8 +38,8 @@ static const char RECONFIGURE[] PROGMEM= "dynamic_reconfigure/Reconfigure";
      return offset;
     }
 
-    virtual const char * getType(const char * type_msg) override { strcpy_P(type_msg, (char *)RECONFIGURE);return type_msg; };
-    virtual const char * getMD5(const char * md5_msg) override { strcpy_P(md5_msg, (char *)dynamic_reconfigure_ReconfigureRequest_md5);return md5_msg; };
+    virtual const char * getType(const char * type_msg) override { strcpy_P((char *)type_msg, (char *)RECONFIGURE);return type_msg; };
+    virtual const char * getMD5(const char * md5_msg) override { strcpy_P((char *)md5_msg, (char *)dynamic_reconfigure_ReconfigureRequest_md5);return md5_msg; };
 
   };
 
@@ -70,8 +70,8 @@ static const char RECONFIGURE[] PROGMEM= "dynamic_reconfigure/Reconfigure";
      return offset;
     }
 
-    virtual const char * getType(const char * type_msg) override { strcpy_P(type_msg, (char *)RECONFIGURE);return type_msg; };
-    virtual const char * getMD5(const char * md5_msg) override { strcpy_P(md5_msg, (char *)dynamic_reconfigure_ReconfigureResponse_md5);return md5_msg; };
+    virtual const char * getType(const char * type_msg) override { strcpy_P((char *)type_msg, (char *)RECONFIGURE);return type_msg; };
+    virtual const char * getMD5(const char * md5_msg) override { strcpy_P((char *)md5_msg, (char *)dynamic_reconfigure_ReconfigureResponse_md5);return md5_msg; };
 
   };
 

--- a/src/dynamic_reconfigure/SensorLevels.h
+++ b/src/dynamic_reconfigure/SensorLevels.h
@@ -34,8 +34,8 @@ namespace dynamic_reconfigure
      return offset;
     }
 
-    virtual const char * getType(const char * type_msg) override { strcpy_P(type_msg, (char *)dynamic_reconfigure_SensorLevels_type);return type_msg; };
-    virtual const char * getMD5(const char * md5_msg) override { strcpy_P(md5_msg, (char *)dynamic_reconfigure_SensorLevels_md5);return md5_msg; };
+    virtual const char * getType(const char * type_msg) override { strcpy_P((char *)type_msg, (char *)dynamic_reconfigure_SensorLevels_type);return type_msg; };
+    virtual const char * getMD5(const char * md5_msg) override { strcpy_P((char *)md5_msg, (char *)dynamic_reconfigure_SensorLevels_md5);return md5_msg; };
 
   };
 

--- a/src/dynamic_reconfigure/StrParameter.h
+++ b/src/dynamic_reconfigure/StrParameter.h
@@ -65,8 +65,8 @@ namespace dynamic_reconfigure
      return offset;
     }
 
-    virtual const char * getType(const char * type_msg) override { strcpy_P(type_msg, (char *)dynamic_reconfigure_StrParameter_type);return type_msg; };
-    virtual const char * getMD5(const char * md5_msg) override { strcpy_P(md5_msg, (char *)dynamic_reconfigure_StrParameter_md5);return md5_msg; };
+    virtual const char * getType(const char * type_msg) override { strcpy_P((char *)type_msg, (char *)dynamic_reconfigure_StrParameter_type);return type_msg; };
+    virtual const char * getMD5(const char * md5_msg) override { strcpy_P((char *)md5_msg, (char *)dynamic_reconfigure_StrParameter_md5);return md5_msg; };
 
   };
 

--- a/src/geometry_msgs/Accel.h
+++ b/src/geometry_msgs/Accel.h
@@ -42,8 +42,8 @@ namespace geometry_msgs
      return offset;
     }
 
-    virtual const char * getType(const char * type_msg) override { strcpy_P(type_msg, (char *)geometry_msgs_Accel_type);return type_msg; };
-    virtual const char * getMD5(const char * md5_msg) override { strcpy_P(md5_msg, (char *)geometry_msgs_Accel_md5);return md5_msg; };
+    virtual const char * getType(const char * type_msg) override { strcpy_P((char *)type_msg, (char *)geometry_msgs_Accel_type);return type_msg; };
+    virtual const char * getMD5(const char * md5_msg) override { strcpy_P((char *)md5_msg, (char *)geometry_msgs_Accel_md5);return md5_msg; };
 
   };
 

--- a/src/geometry_msgs/AccelStamped.h
+++ b/src/geometry_msgs/AccelStamped.h
@@ -43,8 +43,8 @@ namespace geometry_msgs
      return offset;
     }
 
-    virtual const char * getType(const char * type_msg) override { strcpy_P(type_msg, (char *)geometry_msgs_AccelStamped_type);return type_msg; };
-    virtual const char * getMD5(const char * md5_msg) override { strcpy_P(md5_msg, (char *)geometry_msgs_AccelStamped_md5);return md5_msg; };
+    virtual const char * getType(const char * type_msg) override { strcpy_P((char *)type_msg, (char *)geometry_msgs_AccelStamped_type);return type_msg; };
+    virtual const char * getMD5(const char * md5_msg) override { strcpy_P((char *)md5_msg, (char *)geometry_msgs_AccelStamped_md5);return md5_msg; };
 
   };
 

--- a/src/geometry_msgs/AccelWithCovariance.h
+++ b/src/geometry_msgs/AccelWithCovariance.h
@@ -45,8 +45,8 @@ namespace geometry_msgs
      return offset;
     }
 
-    virtual const char * getType(const char * type_msg) override { strcpy_P(type_msg, (char *)geometry_msgs_AccelWithCovariance_type);return type_msg; };
-    virtual const char * getMD5(const char * md5_msg) override { strcpy_P(md5_msg, (char *)geometry_msgs_AccelWithCovariance_md5);return md5_msg; };
+    virtual const char * getType(const char * type_msg) override { strcpy_P((char *)type_msg, (char *)geometry_msgs_AccelWithCovariance_type);return type_msg; };
+    virtual const char * getMD5(const char * md5_msg) override { strcpy_P((char *)md5_msg, (char *)geometry_msgs_AccelWithCovariance_md5);return md5_msg; };
 
   };
 

--- a/src/geometry_msgs/AccelWithCovarianceStamped.h
+++ b/src/geometry_msgs/AccelWithCovarianceStamped.h
@@ -43,8 +43,8 @@ namespace geometry_msgs
      return offset;
     }
 
-    virtual const char * getType(const char * type_msg) override { strcpy_P(type_msg, (char *)geometry_msgs_AccelWithCovarianceStamped_type);return type_msg; };
-    virtual const char * getMD5(const char * md5_msg) override { strcpy_P(md5_msg, (char *)geometry_msgs_AccelWithCovarianceStamped_md5);return md5_msg; };
+    virtual const char * getType(const char * type_msg) override { strcpy_P((char *)type_msg, (char *)geometry_msgs_AccelWithCovarianceStamped_type);return type_msg; };
+    virtual const char * getMD5(const char * md5_msg) override { strcpy_P((char *)md5_msg, (char *)geometry_msgs_AccelWithCovarianceStamped_md5);return md5_msg; };
 
   };
 

--- a/src/geometry_msgs/Inertia.h
+++ b/src/geometry_msgs/Inertia.h
@@ -72,8 +72,8 @@ namespace geometry_msgs
      return offset;
     }
 
-    virtual const char * getType(const char * type_msg) override { strcpy_P(type_msg, (char *)geometry_msgs_Inertia_type);return type_msg; };
-    virtual const char * getMD5(const char * md5_msg) override { strcpy_P(md5_msg, (char *)geometry_msgs_Inertia_md5);return md5_msg; };
+    virtual const char * getType(const char * type_msg) override { strcpy_P((char *)type_msg, (char *)geometry_msgs_Inertia_type);return type_msg; };
+    virtual const char * getMD5(const char * md5_msg) override { strcpy_P((char *)md5_msg, (char *)geometry_msgs_Inertia_md5);return md5_msg; };
 
   };
 

--- a/src/geometry_msgs/InertiaStamped.h
+++ b/src/geometry_msgs/InertiaStamped.h
@@ -43,8 +43,8 @@ namespace geometry_msgs
      return offset;
     }
 
-    virtual const char * getType(const char * type_msg) override { strcpy_P(type_msg, (char *)geometry_msgs_InertiaStamped_type);return type_msg; };
-    virtual const char * getMD5(const char * md5_msg) override { strcpy_P(md5_msg, (char *)geometry_msgs_InertiaStamped_md5);return md5_msg; };
+    virtual const char * getType(const char * type_msg) override { strcpy_P((char *)type_msg, (char *)geometry_msgs_InertiaStamped_type);return type_msg; };
+    virtual const char * getMD5(const char * md5_msg) override { strcpy_P((char *)md5_msg, (char *)geometry_msgs_InertiaStamped_md5);return md5_msg; };
 
   };
 

--- a/src/geometry_msgs/Point.h
+++ b/src/geometry_msgs/Point.h
@@ -46,8 +46,8 @@ namespace geometry_msgs
      return offset;
     }
 
-    virtual const char * getType(const char * type_msg) override { strcpy_P(type_msg, (char *)geometry_msgs_Point_type);return type_msg; };
-    virtual const char * getMD5(const char * md5_msg) override { strcpy_P(md5_msg, (char *)geometry_msgs_Point_md5);return md5_msg; };
+    virtual const char * getType(const char * type_msg) override { strcpy_P((char *)type_msg, (char *)geometry_msgs_Point_type);return type_msg; };
+    virtual const char * getMD5(const char * md5_msg) override { strcpy_P((char *)md5_msg, (char *)geometry_msgs_Point_md5);return md5_msg; };
 
   };
 

--- a/src/geometry_msgs/Point32.h
+++ b/src/geometry_msgs/Point32.h
@@ -103,8 +103,8 @@ namespace geometry_msgs
      return offset;
     }
 
-    virtual const char * getType(const char * type_msg) override { strcpy_P(type_msg, (char *)geometry_msgs_Point32_type);return type_msg; };
-    virtual const char * getMD5(const char * md5_msg) override { strcpy_P(md5_msg, (char *)geometry_msgs_Point32_md5);return md5_msg; };
+    virtual const char * getType(const char * type_msg) override { strcpy_P((char *)type_msg, (char *)geometry_msgs_Point32_type);return type_msg; };
+    virtual const char * getMD5(const char * md5_msg) override { strcpy_P((char *)md5_msg, (char *)geometry_msgs_Point32_md5);return md5_msg; };
 
   };
 

--- a/src/geometry_msgs/PointStamped.h
+++ b/src/geometry_msgs/PointStamped.h
@@ -43,8 +43,8 @@ namespace geometry_msgs
      return offset;
     }
 
-    virtual const char * getType(const char * type_msg) override { strcpy_P(type_msg, (char *)geometry_msgs_PointStamped_type);return type_msg; };
-    virtual const char * getMD5(const char * md5_msg) override { strcpy_P(md5_msg, (char *)geometry_msgs_PointStamped_md5);return md5_msg; };
+    virtual const char * getType(const char * type_msg) override { strcpy_P((char *)type_msg, (char *)geometry_msgs_PointStamped_type);return type_msg; };
+    virtual const char * getMD5(const char * md5_msg) override { strcpy_P((char *)md5_msg, (char *)geometry_msgs_PointStamped_md5);return md5_msg; };
 
   };
 

--- a/src/geometry_msgs/Polygon.h
+++ b/src/geometry_msgs/Polygon.h
@@ -57,8 +57,8 @@ namespace geometry_msgs
      return offset;
     }
 
-    virtual const char * getType(const char * type_msg) override { strcpy_P(type_msg, (char *)geometry_msgs_Polygon_type);return type_msg; };
-    virtual const char * getMD5(const char * md5_msg) override { strcpy_P(md5_msg, (char *)geometry_msgs_Polygon_md5);return md5_msg; };
+    virtual const char * getType(const char * type_msg) override { strcpy_P((char *)type_msg, (char *)geometry_msgs_Polygon_type);return type_msg; };
+    virtual const char * getMD5(const char * md5_msg) override { strcpy_P((char *)md5_msg, (char *)geometry_msgs_Polygon_md5);return md5_msg; };
 
   };
 

--- a/src/geometry_msgs/PolygonStamped.h
+++ b/src/geometry_msgs/PolygonStamped.h
@@ -43,8 +43,8 @@ namespace geometry_msgs
      return offset;
     }
 
-    virtual const char * getType(const char * type_msg) override { strcpy_P(type_msg, (char *)geometry_msgs_PolygonStamped_type);return type_msg; };
-    virtual const char * getMD5(const char * md5_msg) override { strcpy_P(md5_msg, (char *)geometry_msgs_PolygonStamped_md5);return md5_msg; };
+    virtual const char * getType(const char * type_msg) override { strcpy_P((char *)type_msg, (char *)geometry_msgs_PolygonStamped_type);return type_msg; };
+    virtual const char * getMD5(const char * md5_msg) override { strcpy_P((char *)md5_msg, (char *)geometry_msgs_PolygonStamped_md5);return md5_msg; };
 
   };
 

--- a/src/geometry_msgs/Pose.h
+++ b/src/geometry_msgs/Pose.h
@@ -43,8 +43,8 @@ namespace geometry_msgs
      return offset;
     }
 
-    virtual const char * getType(const char * type_msg) override { strcpy_P(type_msg, (char *)geometry_msgs_Pose_type);return type_msg; };
-    virtual const char * getMD5(const char * md5_msg) override { strcpy_P(md5_msg, (char *)geometry_msgs_Pose_md5);return md5_msg; };
+    virtual const char * getType(const char * type_msg) override { strcpy_P((char *)type_msg, (char *)geometry_msgs_Pose_type);return type_msg; };
+    virtual const char * getMD5(const char * md5_msg) override { strcpy_P((char *)md5_msg, (char *)geometry_msgs_Pose_md5);return md5_msg; };
 
   };
 

--- a/src/geometry_msgs/Pose2D.h
+++ b/src/geometry_msgs/Pose2D.h
@@ -46,8 +46,8 @@ namespace geometry_msgs
      return offset;
     }
 
-    virtual const char * getType(const char * type_msg) override { strcpy_P(type_msg, (char *)geometry_msgs_Pose2D_type);return type_msg; };
-    virtual const char * getMD5(const char * md5_msg) override { strcpy_P(md5_msg, (char *)geometry_msgs_Pose2D_md5);return md5_msg; };
+    virtual const char * getType(const char * type_msg) override { strcpy_P((char *)type_msg, (char *)geometry_msgs_Pose2D_type);return type_msg; };
+    virtual const char * getMD5(const char * md5_msg) override { strcpy_P((char *)md5_msg, (char *)geometry_msgs_Pose2D_md5);return md5_msg; };
 
   };
 

--- a/src/geometry_msgs/PoseArray.h
+++ b/src/geometry_msgs/PoseArray.h
@@ -63,8 +63,8 @@ namespace geometry_msgs
      return offset;
     }
 
-    virtual const char * getType(const char * type_msg) override { strcpy_P(type_msg, (char *)geometry_msgs_PoseArray_type);return type_msg; };
-    virtual const char * getMD5(const char * md5_msg) override { strcpy_P(md5_msg, (char *)geometry_msgs_PoseArray_md5);return md5_msg; };
+    virtual const char * getType(const char * type_msg) override { strcpy_P((char *)type_msg, (char *)geometry_msgs_PoseArray_type);return type_msg; };
+    virtual const char * getMD5(const char * md5_msg) override { strcpy_P((char *)md5_msg, (char *)geometry_msgs_PoseArray_md5);return md5_msg; };
 
   };
 

--- a/src/geometry_msgs/PoseStamped.h
+++ b/src/geometry_msgs/PoseStamped.h
@@ -43,8 +43,8 @@ namespace geometry_msgs
      return offset;
     }
 
-    virtual const char * getType(const char * type_msg) override { strcpy_P(type_msg, (char *)geometry_msgs_PoseStamped_type);return type_msg; };
-    virtual const char * getMD5(const char * md5_msg) override { strcpy_P(md5_msg, (char *)geometry_msgs_PoseStamped_md5);return md5_msg; };
+    virtual const char * getType(const char * type_msg) override { strcpy_P((char *)type_msg, (char *)geometry_msgs_PoseStamped_type);return type_msg; };
+    virtual const char * getMD5(const char * md5_msg) override { strcpy_P((char *)md5_msg, (char *)geometry_msgs_PoseStamped_md5);return md5_msg; };
 
   };
 

--- a/src/geometry_msgs/PoseWithCovariance.h
+++ b/src/geometry_msgs/PoseWithCovariance.h
@@ -45,8 +45,8 @@ namespace geometry_msgs
      return offset;
     }
 
-    virtual const char * getType(const char * type_msg) override { strcpy_P(type_msg, (char *)geometry_msgs_PoseWithCovariance_type);return type_msg; };
-    virtual const char * getMD5(const char * md5_msg) override { strcpy_P(md5_msg, (char *)geometry_msgs_PoseWithCovariance_md5);return md5_msg; };
+    virtual const char * getType(const char * type_msg) override { strcpy_P((char *)type_msg, (char *)geometry_msgs_PoseWithCovariance_type);return type_msg; };
+    virtual const char * getMD5(const char * md5_msg) override { strcpy_P((char *)md5_msg, (char *)geometry_msgs_PoseWithCovariance_md5);return md5_msg; };
 
   };
 

--- a/src/geometry_msgs/PoseWithCovarianceStamped.h
+++ b/src/geometry_msgs/PoseWithCovarianceStamped.h
@@ -43,8 +43,8 @@ namespace geometry_msgs
      return offset;
     }
 
-    virtual const char * getType(const char * type_msg) override { strcpy_P(type_msg, (char *)geometry_msgs_PoseWithCovarianceStamped_type);return type_msg; };
-    virtual const char * getMD5(const char * md5_msg) override { strcpy_P(md5_msg, (char *)geometry_msgs_PoseWithCovarianceStamped_md5);return md5_msg; };
+    virtual const char * getType(const char * type_msg) override { strcpy_P((char *)type_msg, (char *)geometry_msgs_PoseWithCovarianceStamped_type);return type_msg; };
+    virtual const char * getMD5(const char * md5_msg) override { strcpy_P((char *)md5_msg, (char *)geometry_msgs_PoseWithCovarianceStamped_md5);return md5_msg; };
 
   };
 

--- a/src/geometry_msgs/Quaternion.h
+++ b/src/geometry_msgs/Quaternion.h
@@ -51,8 +51,8 @@ namespace geometry_msgs
      return offset;
     }
 
-    virtual const char * getType(const char * type_msg) override { strcpy_P(type_msg, (char *)geometry_msgs_Quaternion_type);return type_msg; };
-    virtual const char * getMD5(const char * md5_msg) override { strcpy_P(md5_msg, (char *)geometry_msgs_Quaternion_md5);return md5_msg; };
+    virtual const char * getType(const char * type_msg) override { strcpy_P((char *)type_msg, (char *)geometry_msgs_Quaternion_type);return type_msg; };
+    virtual const char * getMD5(const char * md5_msg) override { strcpy_P((char *)md5_msg, (char *)geometry_msgs_Quaternion_md5);return md5_msg; };
 
   };
 

--- a/src/geometry_msgs/QuaternionStamped.h
+++ b/src/geometry_msgs/QuaternionStamped.h
@@ -43,8 +43,8 @@ namespace geometry_msgs
      return offset;
     }
 
-    virtual const char * getType(const char * type_msg) override { strcpy_P(type_msg, (char *)geometry_msgs_QuaternionStamped_type);return type_msg; };
-    virtual const char * getMD5(const char * md5_msg) override { strcpy_P(md5_msg, (char *)geometry_msgs_QuaternionStamped_md5);return md5_msg; };
+    virtual const char * getType(const char * type_msg) override { strcpy_P((char *)type_msg, (char *)geometry_msgs_QuaternionStamped_type);return type_msg; };
+    virtual const char * getMD5(const char * md5_msg) override { strcpy_P((char *)md5_msg, (char *)geometry_msgs_QuaternionStamped_md5);return md5_msg; };
 
   };
 

--- a/src/geometry_msgs/Transform.h
+++ b/src/geometry_msgs/Transform.h
@@ -43,8 +43,8 @@ namespace geometry_msgs
      return offset;
     }
 
-    virtual const char * getType(const char * type_msg) override { strcpy_P(type_msg, (char *)geometry_msgs_Transform_type);return type_msg; };
-    virtual const char * getMD5(const char * md5_msg) override { strcpy_P(md5_msg, (char *)geometry_msgs_Transform_md5);return md5_msg; };
+    virtual const char * getType(const char * type_msg) override { strcpy_P((char *)type_msg, (char *)geometry_msgs_Transform_type);return type_msg; };
+    virtual const char * getMD5(const char * md5_msg) override { strcpy_P((char *)md5_msg, (char *)geometry_msgs_Transform_md5);return md5_msg; };
 
   };
 

--- a/src/geometry_msgs/TransformStamped.h
+++ b/src/geometry_msgs/TransformStamped.h
@@ -60,8 +60,8 @@ namespace geometry_msgs
      return offset;
     }
 
-    virtual const char * getType(const char * type_msg) override { strcpy_P(type_msg, (char *)geometry_msgs_TransformStamped_type);return type_msg; };
-    virtual const char * getMD5(const char * md5_msg) override { strcpy_P(md5_msg, (char *)geometry_msgs_TransformStamped_md5);return md5_msg; };
+    virtual const char * getType(const char * type_msg) override { strcpy_P((char *)type_msg, (char *)geometry_msgs_TransformStamped_type);return type_msg; };
+    virtual const char * getMD5(const char * md5_msg) override { strcpy_P((char *)md5_msg, (char *)geometry_msgs_TransformStamped_md5);return md5_msg; };
 
   };
 

--- a/src/geometry_msgs/Twist.h
+++ b/src/geometry_msgs/Twist.h
@@ -42,8 +42,8 @@ namespace geometry_msgs
      return offset;
     }
 
-    virtual const char * getType(const char * type_msg) override { strcpy_P(type_msg, (char *)geometry_msgs_Twist_type);return type_msg; };
-    virtual const char * getMD5(const char * md5_msg) override { strcpy_P(md5_msg, (char *)geometry_msgs_Twist_md5);return md5_msg; };
+    virtual const char * getType(const char * type_msg) override { strcpy_P((char *)type_msg, (char *)geometry_msgs_Twist_type);return type_msg; };
+    virtual const char * getMD5(const char * md5_msg) override { strcpy_P((char *)md5_msg, (char *)geometry_msgs_Twist_md5);return md5_msg; };
 
   };
 

--- a/src/geometry_msgs/TwistStamped.h
+++ b/src/geometry_msgs/TwistStamped.h
@@ -43,8 +43,8 @@ namespace geometry_msgs
      return offset;
     }
 
-    virtual const char * getType(const char * type_msg) override { strcpy_P(type_msg, (char *)geometry_msgs_TwistStamped_type);return type_msg; };
-    virtual const char * getMD5(const char * md5_msg) override { strcpy_P(md5_msg, (char *)geometry_msgs_TwistStamped_md5);return md5_msg; };
+    virtual const char * getType(const char * type_msg) override { strcpy_P((char *)type_msg, (char *)geometry_msgs_TwistStamped_type);return type_msg; };
+    virtual const char * getMD5(const char * md5_msg) override { strcpy_P((char *)md5_msg, (char *)geometry_msgs_TwistStamped_md5);return md5_msg; };
 
   };
 

--- a/src/geometry_msgs/TwistWithCovariance.h
+++ b/src/geometry_msgs/TwistWithCovariance.h
@@ -45,8 +45,8 @@ namespace geometry_msgs
      return offset;
     }
 
-    virtual const char * getType(const char * type_msg) override { strcpy_P(type_msg, (char *)geometry_msgs_TwistWithCovariance_type);return type_msg; };
-    virtual const char * getMD5(const char * md5_msg) override { strcpy_P(md5_msg, (char *)geometry_msgs_TwistWithCovariance_md5);return md5_msg; };
+    virtual const char * getType(const char * type_msg) override { strcpy_P((char *)type_msg, (char *)geometry_msgs_TwistWithCovariance_type);return type_msg; };
+    virtual const char * getMD5(const char * md5_msg) override { strcpy_P((char *)md5_msg, (char *)geometry_msgs_TwistWithCovariance_md5);return md5_msg; };
 
   };
 

--- a/src/geometry_msgs/TwistWithCovarianceStamped.h
+++ b/src/geometry_msgs/TwistWithCovarianceStamped.h
@@ -43,8 +43,8 @@ namespace geometry_msgs
      return offset;
     }
 
-    virtual const char * getType(const char * type_msg) override { strcpy_P(type_msg, (char *)geometry_msgs_TwistWithCovarianceStamped_type);return type_msg; };
-    virtual const char * getMD5(const char * md5_msg) override { strcpy_P(md5_msg, (char *)geometry_msgs_TwistWithCovarianceStamped_md5);return md5_msg; };
+    virtual const char * getType(const char * type_msg) override { strcpy_P((char *)type_msg, (char *)geometry_msgs_TwistWithCovarianceStamped_type);return type_msg; };
+    virtual const char * getMD5(const char * md5_msg) override { strcpy_P((char *)md5_msg, (char *)geometry_msgs_TwistWithCovarianceStamped_md5);return md5_msg; };
 
   };
 

--- a/src/geometry_msgs/Vector3.h
+++ b/src/geometry_msgs/Vector3.h
@@ -46,8 +46,8 @@ namespace geometry_msgs
      return offset;
     }
 
-    virtual const char * getType(const char * type_msg) override { strcpy_P(type_msg, (char *)geometry_msgs_Vector3_type);return type_msg; };
-    virtual const char * getMD5(const char * md5_msg) override { strcpy_P(md5_msg, (char *)geometry_msgs_Vector3_md5);return md5_msg; };
+    virtual const char * getType(const char * type_msg) override { strcpy_P((char *)type_msg, (char *)geometry_msgs_Vector3_type);return type_msg; };
+    virtual const char * getMD5(const char * md5_msg) override { strcpy_P((char *)md5_msg, (char *)geometry_msgs_Vector3_md5);return md5_msg; };
 
   };
 

--- a/src/geometry_msgs/Vector3Stamped.h
+++ b/src/geometry_msgs/Vector3Stamped.h
@@ -43,8 +43,8 @@ namespace geometry_msgs
      return offset;
     }
 
-    virtual const char * getType(const char * type_msg) override { strcpy_P(type_msg, (char *)geometry_msgs_Vector3Stamped_type);return type_msg; };
-    virtual const char * getMD5(const char * md5_msg) override { strcpy_P(md5_msg, (char *)geometry_msgs_Vector3Stamped_md5);return md5_msg; };
+    virtual const char * getType(const char * type_msg) override { strcpy_P((char *)type_msg, (char *)geometry_msgs_Vector3Stamped_type);return type_msg; };
+    virtual const char * getMD5(const char * md5_msg) override { strcpy_P((char *)md5_msg, (char *)geometry_msgs_Vector3Stamped_md5);return md5_msg; };
 
   };
 

--- a/src/geometry_msgs/Wrench.h
+++ b/src/geometry_msgs/Wrench.h
@@ -42,8 +42,8 @@ namespace geometry_msgs
      return offset;
     }
 
-    virtual const char * getType(const char * type_msg) override { strcpy_P(type_msg, (char *)geometry_msgs_Wrench_type);return type_msg; };
-    virtual const char * getMD5(const char * md5_msg) override { strcpy_P(md5_msg, (char *)geometry_msgs_Wrench_md5);return md5_msg; };
+    virtual const char * getType(const char * type_msg) override { strcpy_P((char *)type_msg, (char *)geometry_msgs_Wrench_type);return type_msg; };
+    virtual const char * getMD5(const char * md5_msg) override { strcpy_P((char *)md5_msg, (char *)geometry_msgs_Wrench_md5);return md5_msg; };
 
   };
 

--- a/src/geometry_msgs/WrenchStamped.h
+++ b/src/geometry_msgs/WrenchStamped.h
@@ -43,8 +43,8 @@ namespace geometry_msgs
      return offset;
     }
 
-    virtual const char * getType(const char * type_msg) override { strcpy_P(type_msg, (char *)geometry_msgs_WrenchStamped_type);return type_msg; };
-    virtual const char * getMD5(const char * md5_msg) override { strcpy_P(md5_msg, (char *)geometry_msgs_WrenchStamped_md5);return md5_msg; };
+    virtual const char * getType(const char * type_msg) override { strcpy_P((char *)type_msg, (char *)geometry_msgs_WrenchStamped_type);return type_msg; };
+    virtual const char * getMD5(const char * md5_msg) override { strcpy_P((char *)md5_msg, (char *)geometry_msgs_WrenchStamped_md5);return md5_msg; };
 
   };
 

--- a/src/nav_msgs/GetMap.h
+++ b/src/nav_msgs/GetMap.h
@@ -33,8 +33,8 @@ static const char GETMAP[] PROGMEM= "nav_msgs/GetMap";
      return offset;
     }
 
-    virtual const char * getType(const char * type_msg) override { strcpy_P(type_msg, (char *)GETMAP);return type_msg; };
-    virtual const char * getMD5(const char * md5_msg) override { strcpy_P(md5_msg, (char *)nav_msgs_GetMapRequest_md5);return md5_msg; };
+    virtual const char * getType(const char * type_msg) override { strcpy_P((char *)type_msg, (char *)GETMAP);return type_msg; };
+    virtual const char * getMD5(const char * md5_msg) override { strcpy_P((char *)md5_msg, (char *)nav_msgs_GetMapRequest_md5);return md5_msg; };
 
   };
 
@@ -65,8 +65,8 @@ static const char GETMAP[] PROGMEM= "nav_msgs/GetMap";
      return offset;
     }
 
-    virtual const char * getType(const char * type_msg) override { strcpy_P(type_msg, (char *)GETMAP);return type_msg; };
-    virtual const char * getMD5(const char * md5_msg) override { strcpy_P(md5_msg, (char *)nav_msgs_GetMapResponse_md5);return md5_msg; };
+    virtual const char * getType(const char * type_msg) override { strcpy_P((char *)type_msg, (char *)GETMAP);return type_msg; };
+    virtual const char * getMD5(const char * md5_msg) override { strcpy_P((char *)md5_msg, (char *)nav_msgs_GetMapResponse_md5);return md5_msg; };
 
   };
 

--- a/src/nav_msgs/GetMapAction.h
+++ b/src/nav_msgs/GetMapAction.h
@@ -49,8 +49,8 @@ namespace nav_msgs
      return offset;
     }
 
-    virtual const char * getType(const char * type_msg) override { strcpy_P(type_msg, (char *)nav_msgs_GetMapAction_type);return type_msg; };
-    virtual const char * getMD5(const char * md5_msg) override { strcpy_P(md5_msg, (char *)nav_msgs_GetMapAction_md5);return md5_msg; };
+    virtual const char * getType(const char * type_msg) override { strcpy_P((char *)type_msg, (char *)nav_msgs_GetMapAction_type);return type_msg; };
+    virtual const char * getMD5(const char * md5_msg) override { strcpy_P((char *)md5_msg, (char *)nav_msgs_GetMapAction_md5);return md5_msg; };
 
   };
 

--- a/src/nav_msgs/GetMapActionFeedback.h
+++ b/src/nav_msgs/GetMapActionFeedback.h
@@ -49,8 +49,8 @@ namespace nav_msgs
      return offset;
     }
 
-    virtual const char * getType(const char * type_msg) override { strcpy_P(type_msg, (char *)nav_msgs_GetMapActionFeedback_type);return type_msg; };
-    virtual const char * getMD5(const char * md5_msg) override { strcpy_P(md5_msg, (char *)nav_msgs_GetMapActionFeedback_md5);return md5_msg; };
+    virtual const char * getType(const char * type_msg) override { strcpy_P((char *)type_msg, (char *)nav_msgs_GetMapActionFeedback_type);return type_msg; };
+    virtual const char * getMD5(const char * md5_msg) override { strcpy_P((char *)md5_msg, (char *)nav_msgs_GetMapActionFeedback_md5);return md5_msg; };
 
   };
 

--- a/src/nav_msgs/GetMapActionGoal.h
+++ b/src/nav_msgs/GetMapActionGoal.h
@@ -49,8 +49,8 @@ namespace nav_msgs
      return offset;
     }
 
-    virtual const char * getType(const char * type_msg) override { strcpy_P(type_msg, (char *)nav_msgs_GetMapActionGoal_type);return type_msg; };
-    virtual const char * getMD5(const char * md5_msg) override { strcpy_P(md5_msg, (char *)nav_msgs_GetMapActionGoal_md5);return md5_msg; };
+    virtual const char * getType(const char * type_msg) override { strcpy_P((char *)type_msg, (char *)nav_msgs_GetMapActionGoal_type);return type_msg; };
+    virtual const char * getMD5(const char * md5_msg) override { strcpy_P((char *)md5_msg, (char *)nav_msgs_GetMapActionGoal_md5);return md5_msg; };
 
   };
 

--- a/src/nav_msgs/GetMapActionResult.h
+++ b/src/nav_msgs/GetMapActionResult.h
@@ -49,8 +49,8 @@ namespace nav_msgs
      return offset;
     }
 
-    virtual const char * getType(const char * type_msg) override { strcpy_P(type_msg, (char *)nav_msgs_GetMapActionResult_type);return type_msg; };
-    virtual const char * getMD5(const char * md5_msg) override { strcpy_P(md5_msg, (char *)nav_msgs_GetMapActionResult_md5);return md5_msg; };
+    virtual const char * getType(const char * type_msg) override { strcpy_P((char *)type_msg, (char *)nav_msgs_GetMapActionResult_type);return type_msg; };
+    virtual const char * getMD5(const char * md5_msg) override { strcpy_P((char *)md5_msg, (char *)nav_msgs_GetMapActionResult_md5);return md5_msg; };
 
   };
 

--- a/src/nav_msgs/GetMapFeedback.h
+++ b/src/nav_msgs/GetMapFeedback.h
@@ -31,8 +31,8 @@ namespace nav_msgs
      return offset;
     }
 
-    virtual const char * getType(const char * type_msg) override { strcpy_P(type_msg, (char *)nav_msgs_GetMapFeedback_type);return type_msg; };
-    virtual const char * getMD5(const char * md5_msg) override { strcpy_P(md5_msg, (char *)nav_msgs_GetMapFeedback_md5);return md5_msg; };
+    virtual const char * getType(const char * type_msg) override { strcpy_P((char *)type_msg, (char *)nav_msgs_GetMapFeedback_type);return type_msg; };
+    virtual const char * getMD5(const char * md5_msg) override { strcpy_P((char *)md5_msg, (char *)nav_msgs_GetMapFeedback_md5);return md5_msg; };
 
   };
 

--- a/src/nav_msgs/GetMapGoal.h
+++ b/src/nav_msgs/GetMapGoal.h
@@ -31,8 +31,8 @@ namespace nav_msgs
      return offset;
     }
 
-    virtual const char * getType(const char * type_msg) override { strcpy_P(type_msg, (char *)nav_msgs_GetMapGoal_type);return type_msg; };
-    virtual const char * getMD5(const char * md5_msg) override { strcpy_P(md5_msg, (char *)nav_msgs_GetMapGoal_md5);return md5_msg; };
+    virtual const char * getType(const char * type_msg) override { strcpy_P((char *)type_msg, (char *)nav_msgs_GetMapGoal_type);return type_msg; };
+    virtual const char * getMD5(const char * md5_msg) override { strcpy_P((char *)md5_msg, (char *)nav_msgs_GetMapGoal_md5);return md5_msg; };
 
   };
 

--- a/src/nav_msgs/GetMapResult.h
+++ b/src/nav_msgs/GetMapResult.h
@@ -37,8 +37,8 @@ namespace nav_msgs
      return offset;
     }
 
-    virtual const char * getType(const char * type_msg) override { strcpy_P(type_msg, (char *)nav_msgs_GetMapResult_type);return type_msg; };
-    virtual const char * getMD5(const char * md5_msg) override { strcpy_P(md5_msg, (char *)nav_msgs_GetMapResult_md5);return md5_msg; };
+    virtual const char * getType(const char * type_msg) override { strcpy_P((char *)type_msg, (char *)nav_msgs_GetMapResult_type);return type_msg; };
+    virtual const char * getMD5(const char * md5_msg) override { strcpy_P((char *)md5_msg, (char *)nav_msgs_GetMapResult_md5);return md5_msg; };
 
   };
 

--- a/src/nav_msgs/GetPlan.h
+++ b/src/nav_msgs/GetPlan.h
@@ -68,8 +68,8 @@ static const char GETPLAN[] PROGMEM= "nav_msgs/GetPlan";
      return offset;
     }
 
-    virtual const char * getType(const char * type_msg) override { strcpy_P(type_msg, (char *)GETPLAN);return type_msg; };
-    virtual const char * getMD5(const char * md5_msg) override { strcpy_P(md5_msg, (char *)nav_msgs_GetPlanRequest_md5);return md5_msg; };
+    virtual const char * getType(const char * type_msg) override { strcpy_P((char *)type_msg, (char *)GETPLAN);return type_msg; };
+    virtual const char * getMD5(const char * md5_msg) override { strcpy_P((char *)md5_msg, (char *)nav_msgs_GetPlanRequest_md5);return md5_msg; };
 
   };
 
@@ -100,8 +100,8 @@ static const char GETPLAN[] PROGMEM= "nav_msgs/GetPlan";
      return offset;
     }
 
-    virtual const char * getType(const char * type_msg) override { strcpy_P(type_msg, (char *)GETPLAN);return type_msg; };
-    virtual const char * getMD5(const char * md5_msg) override { strcpy_P(md5_msg, (char *)nav_msgs_GetPlanResponse_md5);return md5_msg; };
+    virtual const char * getType(const char * type_msg) override { strcpy_P((char *)type_msg, (char *)GETPLAN);return type_msg; };
+    virtual const char * getMD5(const char * md5_msg) override { strcpy_P((char *)md5_msg, (char *)nav_msgs_GetPlanResponse_md5);return md5_msg; };
 
   };
 

--- a/src/nav_msgs/GridCells.h
+++ b/src/nav_msgs/GridCells.h
@@ -111,8 +111,8 @@ namespace nav_msgs
      return offset;
     }
 
-    virtual const char * getType(const char * type_msg) override { strcpy_P(type_msg, (char *)nav_msgs_GridCells_type);return type_msg; };
-    virtual const char * getMD5(const char * md5_msg) override { strcpy_P(md5_msg, (char *)nav_msgs_GridCells_md5);return md5_msg; };
+    virtual const char * getType(const char * type_msg) override { strcpy_P((char *)type_msg, (char *)nav_msgs_GridCells_type);return type_msg; };
+    virtual const char * getMD5(const char * md5_msg) override { strcpy_P((char *)md5_msg, (char *)nav_msgs_GridCells_md5);return md5_msg; };
 
   };
 

--- a/src/nav_msgs/MapMetaData.h
+++ b/src/nav_msgs/MapMetaData.h
@@ -111,8 +111,8 @@ namespace nav_msgs
      return offset;
     }
 
-    virtual const char * getType(const char * type_msg) override { strcpy_P(type_msg, (char *)nav_msgs_MapMetaData_type);return type_msg; };
-    virtual const char * getMD5(const char * md5_msg) override { strcpy_P(md5_msg, (char *)nav_msgs_MapMetaData_md5);return md5_msg; };
+    virtual const char * getType(const char * type_msg) override { strcpy_P((char *)type_msg, (char *)nav_msgs_MapMetaData_type);return type_msg; };
+    virtual const char * getMD5(const char * md5_msg) override { strcpy_P((char *)md5_msg, (char *)nav_msgs_MapMetaData_md5);return md5_msg; };
 
   };
 

--- a/src/nav_msgs/OccupancyGrid.h
+++ b/src/nav_msgs/OccupancyGrid.h
@@ -81,8 +81,8 @@ namespace nav_msgs
      return offset;
     }
 
-    virtual const char * getType(const char * type_msg) override { strcpy_P(type_msg, (char *)nav_msgs_OccupancyGrid_type);return type_msg; };
-    virtual const char * getMD5(const char * md5_msg) override { strcpy_P(md5_msg, (char *)nav_msgs_OccupancyGrid_md5);return md5_msg; };
+    virtual const char * getType(const char * type_msg) override { strcpy_P((char *)type_msg, (char *)nav_msgs_OccupancyGrid_type);return type_msg; };
+    virtual const char * getMD5(const char * md5_msg) override { strcpy_P((char *)md5_msg, (char *)nav_msgs_OccupancyGrid_md5);return md5_msg; };
 
   };
 

--- a/src/nav_msgs/Odometry.h
+++ b/src/nav_msgs/Odometry.h
@@ -66,8 +66,8 @@ namespace nav_msgs
      return offset;
     }
 
-    virtual const char * getType(const char * type_msg) override { strcpy_P(type_msg, (char *)nav_msgs_Odometry_type);return type_msg; };
-    virtual const char * getMD5(const char * md5_msg) override { strcpy_P(md5_msg, (char *)nav_msgs_Odometry_md5);return md5_msg; };
+    virtual const char * getType(const char * type_msg) override { strcpy_P((char *)type_msg, (char *)nav_msgs_Odometry_type);return type_msg; };
+    virtual const char * getMD5(const char * md5_msg) override { strcpy_P((char *)md5_msg, (char *)nav_msgs_Odometry_md5);return md5_msg; };
 
   };
 

--- a/src/nav_msgs/Path.h
+++ b/src/nav_msgs/Path.h
@@ -63,8 +63,8 @@ namespace nav_msgs
      return offset;
     }
 
-    virtual const char * getType(const char * type_msg) override { strcpy_P(type_msg, (char *)nav_msgs_Path_type);return type_msg; };
-    virtual const char * getMD5(const char * md5_msg) override { strcpy_P(md5_msg, (char *)nav_msgs_Path_md5);return md5_msg; };
+    virtual const char * getType(const char * type_msg) override { strcpy_P((char *)type_msg, (char *)nav_msgs_Path_type);return type_msg; };
+    virtual const char * getMD5(const char * md5_msg) override { strcpy_P((char *)md5_msg, (char *)nav_msgs_Path_md5);return md5_msg; };
 
   };
 

--- a/src/nav_msgs/SetMap.h
+++ b/src/nav_msgs/SetMap.h
@@ -44,8 +44,8 @@ static const char SETMAP[] PROGMEM= "nav_msgs/SetMap";
      return offset;
     }
 
-    virtual const char * getType(const char * type_msg) override { strcpy_P(type_msg, (char *)SETMAP);return type_msg; };
-    virtual const char * getMD5(const char * md5_msg) override { strcpy_P(md5_msg, (char *)nav_msgs_SetMapRequest_md5);return md5_msg; };
+    virtual const char * getType(const char * type_msg) override { strcpy_P((char *)type_msg, (char *)SETMAP);return type_msg; };
+    virtual const char * getMD5(const char * md5_msg) override { strcpy_P((char *)md5_msg, (char *)nav_msgs_SetMapRequest_md5);return md5_msg; };
 
   };
 
@@ -89,8 +89,8 @@ static const char SETMAP[] PROGMEM= "nav_msgs/SetMap";
      return offset;
     }
 
-    virtual const char * getType(const char * type_msg) override { strcpy_P(type_msg, (char *)SETMAP);return type_msg; };
-    virtual const char * getMD5(const char * md5_msg) override { strcpy_P(md5_msg, (char *)nav_msgs_SetMapResponse_md5);return md5_msg; };
+    virtual const char * getType(const char * type_msg) override { strcpy_P((char *)type_msg, (char *)SETMAP);return type_msg; };
+    virtual const char * getMD5(const char * md5_msg) override { strcpy_P((char *)md5_msg, (char *)nav_msgs_SetMapResponse_md5);return md5_msg; };
 
   };
 

--- a/src/nodelet/NodeletList.h
+++ b/src/nodelet/NodeletList.h
@@ -32,8 +32,8 @@ static const char NODELETLIST[] PROGMEM= "nodelet/NodeletList";
      return offset;
     }
 
-    virtual const char * getType(const char * type_msg) override { strcpy_P(type_msg, (char *)NODELETLIST);return type_msg; };
-    virtual const char * getMD5(const char * md5_msg) override { strcpy_P(md5_msg, (char *)nodelet_NodeletListRequest_md5);return md5_msg; };
+    virtual const char * getType(const char * type_msg) override { strcpy_P((char *)type_msg, (char *)NODELETLIST);return type_msg; };
+    virtual const char * getMD5(const char * md5_msg) override { strcpy_P((char *)md5_msg, (char *)nodelet_NodeletListRequest_md5);return md5_msg; };
 
   };
 
@@ -96,8 +96,8 @@ static const char NODELETLIST[] PROGMEM= "nodelet/NodeletList";
      return offset;
     }
 
-    virtual const char * getType(const char * type_msg) override { strcpy_P(type_msg, (char *)NODELETLIST);return type_msg; };
-    virtual const char * getMD5(const char * md5_msg) override { strcpy_P(md5_msg, (char *)nodelet_NodeletListResponse_md5);return md5_msg; };
+    virtual const char * getType(const char * type_msg) override { strcpy_P((char *)type_msg, (char *)NODELETLIST);return type_msg; };
+    virtual const char * getMD5(const char * md5_msg) override { strcpy_P((char *)md5_msg, (char *)nodelet_NodeletListResponse_md5);return md5_msg; };
 
   };
 

--- a/src/nodelet/NodeletLoad.h
+++ b/src/nodelet/NodeletLoad.h
@@ -194,8 +194,8 @@ static const char NODELETLOAD[] PROGMEM= "nodelet/NodeletLoad";
      return offset;
     }
 
-    virtual const char * getType(const char * type_msg) override { strcpy_P(type_msg, (char *)NODELETLOAD);return type_msg; };
-    virtual const char * getMD5(const char * md5_msg) override { strcpy_P(md5_msg, (char *)nodelet_NodeletLoadRequest_md5);return md5_msg; };
+    virtual const char * getType(const char * type_msg) override { strcpy_P((char *)type_msg, (char *)NODELETLOAD);return type_msg; };
+    virtual const char * getMD5(const char * md5_msg) override { strcpy_P((char *)md5_msg, (char *)nodelet_NodeletLoadRequest_md5);return md5_msg; };
 
   };
 
@@ -239,8 +239,8 @@ static const char NODELETLOAD[] PROGMEM= "nodelet/NodeletLoad";
      return offset;
     }
 
-    virtual const char * getType(const char * type_msg) override { strcpy_P(type_msg, (char *)NODELETLOAD);return type_msg; };
-    virtual const char * getMD5(const char * md5_msg) override { strcpy_P(md5_msg, (char *)nodelet_NodeletLoadResponse_md5);return md5_msg; };
+    virtual const char * getType(const char * type_msg) override { strcpy_P((char *)type_msg, (char *)NODELETLOAD);return type_msg; };
+    virtual const char * getMD5(const char * md5_msg) override { strcpy_P((char *)md5_msg, (char *)nodelet_NodeletLoadResponse_md5);return md5_msg; };
 
   };
 

--- a/src/nodelet/NodeletUnload.h
+++ b/src/nodelet/NodeletUnload.h
@@ -49,8 +49,8 @@ static const char NODELETUNLOAD[] PROGMEM= "nodelet/NodeletUnload";
      return offset;
     }
 
-    virtual const char * getType(const char * type_msg) override { strcpy_P(type_msg, (char *)NODELETUNLOAD);return type_msg; };
-    virtual const char * getMD5(const char * md5_msg) override { strcpy_P(md5_msg, (char *)nodelet_NodeletUnloadRequest_md5);return md5_msg; };
+    virtual const char * getType(const char * type_msg) override { strcpy_P((char *)type_msg, (char *)NODELETUNLOAD);return type_msg; };
+    virtual const char * getMD5(const char * md5_msg) override { strcpy_P((char *)md5_msg, (char *)nodelet_NodeletUnloadRequest_md5);return md5_msg; };
 
   };
 
@@ -94,8 +94,8 @@ static const char NODELETUNLOAD[] PROGMEM= "nodelet/NodeletUnload";
      return offset;
     }
 
-    virtual const char * getType(const char * type_msg) override { strcpy_P(type_msg, (char *)NODELETUNLOAD);return type_msg; };
-    virtual const char * getMD5(const char * md5_msg) override { strcpy_P(md5_msg, (char *)nodelet_NodeletUnloadResponse_md5);return md5_msg; };
+    virtual const char * getType(const char * type_msg) override { strcpy_P((char *)type_msg, (char *)NODELETUNLOAD);return type_msg; };
+    virtual const char * getMD5(const char * md5_msg) override { strcpy_P((char *)md5_msg, (char *)nodelet_NodeletUnloadResponse_md5);return md5_msg; };
 
   };
 

--- a/src/ros.h
+++ b/src/ros.h
@@ -37,7 +37,7 @@
 
 #include "ros/node_handle.h"
 
-#if defined(ESP8266) or defined(ESP32) or defined(ROSSERIAL_ARDUINO_TCP) or defined(NINA_GPIO0)
+#if (defined(ESP8266) or defined(ESP32) or defined(NINA_GPIO0)) and defined(ROSSERIAL_ARDUINO_TCP)
   #include "ArduinoTcpHardware.h"
 #else
   #include "ArduinoHardware.h"

--- a/src/roscpp/Empty.h
+++ b/src/roscpp/Empty.h
@@ -32,8 +32,8 @@ static const char EMPTY[] PROGMEM= "roscpp/Empty";
      return offset;
     }
 
-    virtual const char * getType(const char * type_msg) override { strcpy_P(type_msg, (char *)EMPTY);return type_msg; };
-    virtual const char * getMD5(const char * md5_msg) override { strcpy_P(md5_msg, (char *)roscpp_EmptyRequest_md5);return md5_msg; };
+    virtual const char * getType(const char * type_msg) override { strcpy_P((char *)type_msg, (char *)EMPTY);return type_msg; };
+    virtual const char * getMD5(const char * md5_msg) override { strcpy_P((char *)md5_msg, (char *)roscpp_EmptyRequest_md5);return md5_msg; };
 
   };
 
@@ -59,8 +59,8 @@ static const char EMPTY[] PROGMEM= "roscpp/Empty";
      return offset;
     }
 
-    virtual const char * getType(const char * type_msg) override { strcpy_P(type_msg, (char *)EMPTY);return type_msg; };
-    virtual const char * getMD5(const char * md5_msg) override { strcpy_P(md5_msg, (char *)roscpp_EmptyResponse_md5);return md5_msg; };
+    virtual const char * getType(const char * type_msg) override { strcpy_P((char *)type_msg, (char *)EMPTY);return type_msg; };
+    virtual const char * getMD5(const char * md5_msg) override { strcpy_P((char *)md5_msg, (char *)roscpp_EmptyResponse_md5);return md5_msg; };
 
   };
 

--- a/src/roscpp/GetLoggers.h
+++ b/src/roscpp/GetLoggers.h
@@ -33,8 +33,8 @@ static const char GETLOGGERS[] PROGMEM= "roscpp/GetLoggers";
      return offset;
     }
 
-    virtual const char * getType(const char * type_msg) override { strcpy_P(type_msg, (char *)GETLOGGERS);return type_msg; };
-    virtual const char * getMD5(const char * md5_msg) override { strcpy_P(md5_msg, (char *)roscpp_GetLoggersRequest_md5);return md5_msg; };
+    virtual const char * getType(const char * type_msg) override { strcpy_P((char *)type_msg, (char *)GETLOGGERS);return type_msg; };
+    virtual const char * getMD5(const char * md5_msg) override { strcpy_P((char *)md5_msg, (char *)roscpp_GetLoggersRequest_md5);return md5_msg; };
 
   };
 
@@ -85,8 +85,8 @@ static const char GETLOGGERS[] PROGMEM= "roscpp/GetLoggers";
      return offset;
     }
 
-    virtual const char * getType(const char * type_msg) override { strcpy_P(type_msg, (char *)GETLOGGERS);return type_msg; };
-    virtual const char * getMD5(const char * md5_msg) override { strcpy_P(md5_msg, (char *)roscpp_GetLoggersResponse_md5);return md5_msg; };
+    virtual const char * getType(const char * type_msg) override { strcpy_P((char *)type_msg, (char *)GETLOGGERS);return type_msg; };
+    virtual const char * getMD5(const char * md5_msg) override { strcpy_P((char *)md5_msg, (char *)roscpp_GetLoggersResponse_md5);return md5_msg; };
 
   };
 

--- a/src/roscpp/Logger.h
+++ b/src/roscpp/Logger.h
@@ -65,8 +65,8 @@ namespace roscpp
      return offset;
     }
 
-    virtual const char * getType(const char * type_msg) override { strcpy_P(type_msg, (char *)roscpp_Logger_type);return type_msg; };
-    virtual const char * getMD5(const char * md5_msg) override { strcpy_P(md5_msg, (char *)roscpp_Logger_md5);return md5_msg; };
+    virtual const char * getType(const char * type_msg) override { strcpy_P((char *)type_msg, (char *)roscpp_Logger_type);return type_msg; };
+    virtual const char * getMD5(const char * md5_msg) override { strcpy_P((char *)md5_msg, (char *)roscpp_Logger_md5);return md5_msg; };
 
   };
 

--- a/src/roscpp/SetLoggerLevel.h
+++ b/src/roscpp/SetLoggerLevel.h
@@ -66,8 +66,8 @@ static const char SETLOGGERLEVEL[] PROGMEM= "roscpp/SetLoggerLevel";
      return offset;
     }
 
-    virtual const char * getType(const char * type_msg) override { strcpy_P(type_msg, (char *)SETLOGGERLEVEL);return type_msg; };
-    virtual const char * getMD5(const char * md5_msg) override { strcpy_P(md5_msg, (char *)roscpp_SetLoggerLevelRequest_md5);return md5_msg; };
+    virtual const char * getType(const char * type_msg) override { strcpy_P((char *)type_msg, (char *)SETLOGGERLEVEL);return type_msg; };
+    virtual const char * getMD5(const char * md5_msg) override { strcpy_P((char *)md5_msg, (char *)roscpp_SetLoggerLevelRequest_md5);return md5_msg; };
 
   };
 
@@ -93,8 +93,8 @@ static const char SETLOGGERLEVEL[] PROGMEM= "roscpp/SetLoggerLevel";
      return offset;
     }
 
-    virtual const char * getType(const char * type_msg) override { strcpy_P(type_msg, (char *)SETLOGGERLEVEL);return type_msg; };
-    virtual const char * getMD5(const char * md5_msg) override { strcpy_P(md5_msg, (char *)roscpp_SetLoggerLevelResponse_md5);return md5_msg; };
+    virtual const char * getType(const char * type_msg) override { strcpy_P((char *)type_msg, (char *)SETLOGGERLEVEL);return type_msg; };
+    virtual const char * getMD5(const char * md5_msg) override { strcpy_P((char *)md5_msg, (char *)roscpp_SetLoggerLevelResponse_md5);return md5_msg; };
 
   };
 

--- a/src/rosgraph_msgs/Clock.h
+++ b/src/rosgraph_msgs/Clock.h
@@ -55,8 +55,8 @@ namespace rosgraph_msgs
      return offset;
     }
 
-    virtual const char * getType(const char * type_msg) override { strcpy_P(type_msg, (char *)rosgraph_msgs_Clock_type);return type_msg; };
-    virtual const char * getMD5(const char * md5_msg) override { strcpy_P(md5_msg, (char *)rosgraph_msgs_Clock_md5);return md5_msg; };
+    virtual const char * getType(const char * type_msg) override { strcpy_P((char *)type_msg, (char *)rosgraph_msgs_Clock_type);return type_msg; };
+    virtual const char * getMD5(const char * md5_msg) override { strcpy_P((char *)md5_msg, (char *)rosgraph_msgs_Clock_md5);return md5_msg; };
 
   };
 

--- a/src/rosgraph_msgs/Log.h
+++ b/src/rosgraph_msgs/Log.h
@@ -178,8 +178,8 @@ namespace rosgraph_msgs
      return offset;
     }
 
-    virtual const char * getType(const char * type_msg) override { strcpy_P(type_msg, (char *)rosgraph_msgs_Log_type);return type_msg; };
-    virtual const char * getMD5(const char * md5_msg) override { strcpy_P(md5_msg, (char *)rosgraph_msgs_Log_md5);return md5_msg; };
+    virtual const char * getType(const char * type_msg) override { strcpy_P((char *)type_msg, (char *)rosgraph_msgs_Log_type);return type_msg; };
+    virtual const char * getMD5(const char * md5_msg) override { strcpy_P((char *)md5_msg, (char *)rosgraph_msgs_Log_md5);return md5_msg; };
 
   };
 

--- a/src/rosgraph_msgs/TopicStatistics.h
+++ b/src/rosgraph_msgs/TopicStatistics.h
@@ -340,8 +340,8 @@ namespace rosgraph_msgs
      return offset;
     }
 
-    virtual const char * getType(const char * type_msg) override { strcpy_P(type_msg, (char *)rosgraph_msgs_TopicStatistics_type);return type_msg; };
-    virtual const char * getMD5(const char * md5_msg) override { strcpy_P(md5_msg, (char *)rosgraph_msgs_TopicStatistics_md5);return md5_msg; };
+    virtual const char * getType(const char * type_msg) override { strcpy_P((char *)type_msg, (char *)rosgraph_msgs_TopicStatistics_type);return type_msg; };
+    virtual const char * getMD5(const char * md5_msg) override { strcpy_P((char *)md5_msg, (char *)rosgraph_msgs_TopicStatistics_md5);return md5_msg; };
 
   };
 

--- a/src/rosserial_arduino/Adc.h
+++ b/src/rosserial_arduino/Adc.h
@@ -89,12 +89,12 @@ namespace rosserial_arduino
     #ifdef ESP8266
         const char * getType() { return  ("rosserial_arduino/Adc");};
     #else
-        virtual const char * getType(const char * type_msg) override { strcpy_P(type_msg, (char *)rosserial_arduino_Adc_type);return type_msg; };
+        virtual const char * getType(const char * type_msg) override { strcpy_P((char *)type_msg, (char *)rosserial_arduino_Adc_type);return type_msg; };
     #endif
     #ifdef ESP8266
         const char * getMD5() { return  ("6d7853a614e2e821319068311f2af25b");};
     #else
-        virtual const char * getMD5(const char * md5_msg) override { strcpy_P(md5_msg, (char *)rosserial_arduino_Adc_md5);return md5_msg; };
+        virtual const char * getMD5(const char * md5_msg) override { strcpy_P((char *)md5_msg, (char *)rosserial_arduino_Adc_md5);return md5_msg; };
     #endif
 
   };

--- a/src/rosserial_arduino/Test.h
+++ b/src/rosserial_arduino/Test.h
@@ -58,8 +58,8 @@ namespace rosserial_arduino
         const char * getType(){ return TEST; };
         const char * getMD5() { return  ("39e92f1778057359c64c7b8a7d7b19de");};
     #else
-        virtual const char * getType(const char * type_msg) override { strcpy_P(type_msg, (char *)TEST);return type_msg; };
-        virtual const char * getMD5(const char * md5_msg) override { strcpy_P(md5_msg, (char *)rosserial_arduino_TestRequest_md5);return md5_msg; };
+        virtual const char * getType(const char * type_msg) override { strcpy_P((char *)type_msg, (char *)TEST);return type_msg; };
+        virtual const char * getMD5(const char * md5_msg) override { strcpy_P((char *)md5_msg, (char *)rosserial_arduino_TestRequest_md5);return md5_msg; };
     #endif
 
   };
@@ -107,8 +107,8 @@ namespace rosserial_arduino
         const char * getType(){ return TEST; };
         const char * getMD5() { return  ("0825d95fdfa2c8f4bbb4e9c74bccd3fd");};
     #else
-        virtual const char * getType(const char * type_msg) override { strcpy_P(type_msg, (char *)TEST);return type_msg; };
-        virtual const char * getMD5(const char * md5_msg) override { strcpy_P(md5_msg, (char *)rosserial_arduino_TestResponse_md5);return md5_msg; };
+        virtual const char * getType(const char * type_msg) override { strcpy_P((char *)type_msg, (char *)TEST);return type_msg; };
+        virtual const char * getMD5(const char * md5_msg) override { strcpy_P((char *)md5_msg, (char *)rosserial_arduino_TestResponse_md5);return md5_msg; };
     #endif
 
   };

--- a/src/rosserial_msgs/Log.h
+++ b/src/rosserial_msgs/Log.h
@@ -60,8 +60,8 @@ namespace rosserial_msgs
      return offset;
     }
 
-    virtual const char * getType(const char * type_msg) override { strcpy_P(type_msg, (char *)rosserial_msgs_Log_type);return type_msg; };
-    virtual const char * getMD5(const char * md5_msg) override { strcpy_P(md5_msg, (char *)rosserial_msgs_Log_md5);return md5_msg; };
+    virtual const char * getType(const char * type_msg) override { strcpy_P((char *)type_msg, (char *)rosserial_msgs_Log_type);return type_msg; };
+    virtual const char * getMD5(const char * md5_msg) override { strcpy_P((char *)md5_msg, (char *)rosserial_msgs_Log_md5);return md5_msg; };
 
   };
 

--- a/src/rosserial_msgs/RequestParam.h
+++ b/src/rosserial_msgs/RequestParam.h
@@ -49,8 +49,8 @@ static const char REQUESTPARAM[] PROGMEM= "rosserial_msgs/RequestParam";
      return offset;
     }
 
-    virtual const char * getType(const char * type_msg) override { strcpy_P(type_msg, (char *)REQUESTPARAM);return type_msg; };
-    virtual const char * getMD5(const char * md5_msg) override { strcpy_P(md5_msg, (char *)rosserial_msgs_RequestParamRequest_md5);return md5_msg; };
+    virtual const char * getType(const char * type_msg) override { strcpy_P((char *)type_msg, (char *)REQUESTPARAM);return type_msg; };
+    virtual const char * getMD5(const char * md5_msg) override { strcpy_P((char *)md5_msg, (char *)rosserial_msgs_RequestParamRequest_md5);return md5_msg; };
 
   };
 
@@ -201,8 +201,8 @@ static const char REQUESTPARAM[] PROGMEM= "rosserial_msgs/RequestParam";
      return offset;
     }
 
-    virtual const char * getType(const char * type_msg) override { strcpy_P(type_msg, (char *)REQUESTPARAM);return type_msg; };
-    virtual const char * getMD5(const char * md5_msg) override { strcpy_P(md5_msg, (char *)rosserial_msgs_RequestParamResponse_md5);return md5_msg; };
+    virtual const char * getType(const char * type_msg) override { strcpy_P((char *)type_msg, (char *)REQUESTPARAM);return type_msg; };
+    virtual const char * getMD5(const char * md5_msg) override { strcpy_P((char *)md5_msg, (char *)rosserial_msgs_RequestParamResponse_md5);return md5_msg; };
 
   };
 

--- a/src/rosserial_msgs/TopicInfo.h
+++ b/src/rosserial_msgs/TopicInfo.h
@@ -123,8 +123,8 @@ namespace rosserial_msgs
      return offset;
     }
 
-    virtual const char * getType(const char * type_msg) override { strcpy_P(type_msg, (char *)rosserial_msgs_TopicInfo_type);return type_msg; };
-    virtual const char * getMD5(const char * md5_msg) override { strcpy_P(md5_msg, (char *)rosserial_msgs_TopicInfo_md5);return md5_msg; };
+    virtual const char * getType(const char * type_msg) override { strcpy_P((char *)type_msg, (char *)rosserial_msgs_TopicInfo_type);return type_msg; };
+    virtual const char * getMD5(const char * md5_msg) override { strcpy_P((char *)md5_msg, (char *)rosserial_msgs_TopicInfo_md5);return md5_msg; };
 
   };
 

--- a/src/sensor_msgs/BatteryState.h
+++ b/src/sensor_msgs/BatteryState.h
@@ -387,8 +387,8 @@ namespace sensor_msgs
      return offset;
     }
 
-    virtual const char * getType(const char * type_msg) override { strcpy_P(type_msg, (char *)sensor_msgs_BatteryState_type);return type_msg; };
-    virtual const char * getMD5(const char * md5_msg) override { strcpy_P(md5_msg, (char *)sensor_msgs_BatteryState_md5);return md5_msg; };
+    virtual const char * getType(const char * type_msg) override { strcpy_P((char *)type_msg, (char *)sensor_msgs_BatteryState_type);return type_msg; };
+    virtual const char * getMD5(const char * md5_msg) override { strcpy_P((char *)md5_msg, (char *)sensor_msgs_BatteryState_md5);return md5_msg; };
 
   };
 

--- a/src/sensor_msgs/CameraInfo.h
+++ b/src/sensor_msgs/CameraInfo.h
@@ -161,8 +161,8 @@ namespace sensor_msgs
      return offset;
     }
 
-    virtual const char * getType(const char * type_msg) override { strcpy_P(type_msg, (char *)sensor_msgs_CameraInfo_type);return type_msg; };
-    virtual const char * getMD5(const char * md5_msg) override { strcpy_P(md5_msg, (char *)sensor_msgs_CameraInfo_md5);return md5_msg; };
+    virtual const char * getType(const char * type_msg) override { strcpy_P((char *)type_msg, (char *)sensor_msgs_CameraInfo_type);return type_msg; };
+    virtual const char * getMD5(const char * md5_msg) override { strcpy_P((char *)md5_msg, (char *)sensor_msgs_CameraInfo_md5);return md5_msg; };
 
   };
 

--- a/src/sensor_msgs/ChannelFloat32.h
+++ b/src/sensor_msgs/ChannelFloat32.h
@@ -92,8 +92,8 @@ namespace sensor_msgs
      return offset;
     }
 
-    virtual const char * getType(const char * type_msg) override { strcpy_P(type_msg, (char *)sensor_msgs_ChannelFloat32_type);return type_msg; };
-    virtual const char * getMD5(const char * md5_msg) override { strcpy_P(md5_msg, (char *)sensor_msgs_ChannelFloat32_md5);return md5_msg; };
+    virtual const char * getType(const char * type_msg) override { strcpy_P((char *)type_msg, (char *)sensor_msgs_ChannelFloat32_type);return type_msg; };
+    virtual const char * getMD5(const char * md5_msg) override { strcpy_P((char *)md5_msg, (char *)sensor_msgs_ChannelFloat32_md5);return md5_msg; };
 
   };
 

--- a/src/sensor_msgs/CompressedImage.h
+++ b/src/sensor_msgs/CompressedImage.h
@@ -81,8 +81,8 @@ namespace sensor_msgs
      return offset;
     }
 
-    virtual const char * getType(const char * type_msg) override { strcpy_P(type_msg, (char *)sensor_msgs_CompressedImage_type);return type_msg; };
-    virtual const char * getMD5(const char * md5_msg) override { strcpy_P(md5_msg, (char *)sensor_msgs_CompressedImage_md5);return md5_msg; };
+    virtual const char * getType(const char * type_msg) override { strcpy_P((char *)type_msg, (char *)sensor_msgs_CompressedImage_type);return type_msg; };
+    virtual const char * getMD5(const char * md5_msg) override { strcpy_P((char *)md5_msg, (char *)sensor_msgs_CompressedImage_md5);return md5_msg; };
 
   };
 

--- a/src/sensor_msgs/FluidPressure.h
+++ b/src/sensor_msgs/FluidPressure.h
@@ -47,8 +47,8 @@ namespace sensor_msgs
      return offset;
     }
 
-    virtual const char * getType(const char * type_msg) override { strcpy_P(type_msg, (char *)sensor_msgs_FluidPressure_type);return type_msg; };
-    virtual const char * getMD5(const char * md5_msg) override { strcpy_P(md5_msg, (char *)sensor_msgs_FluidPressure_md5);return md5_msg; };
+    virtual const char * getType(const char * type_msg) override { strcpy_P((char *)type_msg, (char *)sensor_msgs_FluidPressure_type);return type_msg; };
+    virtual const char * getMD5(const char * md5_msg) override { strcpy_P((char *)md5_msg, (char *)sensor_msgs_FluidPressure_md5);return md5_msg; };
 
   };
 

--- a/src/sensor_msgs/Illuminance.h
+++ b/src/sensor_msgs/Illuminance.h
@@ -47,8 +47,8 @@ namespace sensor_msgs
      return offset;
     }
 
-    virtual const char * getType(const char * type_msg) override { strcpy_P(type_msg, (char *)sensor_msgs_Illuminance_type);return type_msg; };
-    virtual const char * getMD5(const char * md5_msg) override { strcpy_P(md5_msg, (char *)sensor_msgs_Illuminance_md5);return md5_msg; };
+    virtual const char * getType(const char * type_msg) override { strcpy_P((char *)type_msg, (char *)sensor_msgs_Illuminance_type);return type_msg; };
+    virtual const char * getMD5(const char * md5_msg) override { strcpy_P((char *)md5_msg, (char *)sensor_msgs_Illuminance_md5);return md5_msg; };
 
   };
 

--- a/src/sensor_msgs/Image.h
+++ b/src/sensor_msgs/Image.h
@@ -127,8 +127,8 @@ namespace sensor_msgs
      return offset;
     }
 
-    virtual const char * getType(const char * type_msg) override { strcpy_P(type_msg, (char *)sensor_msgs_Image_type);return type_msg; };
-    virtual const char * getMD5(const char * md5_msg) override { strcpy_P(md5_msg, (char *)sensor_msgs_Image_md5);return md5_msg; };
+    virtual const char * getType(const char * type_msg) override { strcpy_P((char *)type_msg, (char *)sensor_msgs_Image_type);return type_msg; };
+    virtual const char * getMD5(const char * md5_msg) override { strcpy_P((char *)md5_msg, (char *)sensor_msgs_Image_md5);return md5_msg; };
 
   };
 

--- a/src/sensor_msgs/Imu.h
+++ b/src/sensor_msgs/Imu.h
@@ -78,8 +78,8 @@ namespace sensor_msgs
      return offset;
     }
 
-    virtual const char * getType(const char * type_msg) override { strcpy_P(type_msg, (char *)sensor_msgs_Imu_type);return type_msg; };
-    virtual const char * getMD5(const char * md5_msg) override { strcpy_P(md5_msg, (char *)sensor_msgs_Imu_md5);return md5_msg; };
+    virtual const char * getType(const char * type_msg) override { strcpy_P((char *)type_msg, (char *)sensor_msgs_Imu_type);return type_msg; };
+    virtual const char * getMD5(const char * md5_msg) override { strcpy_P((char *)md5_msg, (char *)sensor_msgs_Imu_md5);return md5_msg; };
 
   };
 

--- a/src/sensor_msgs/JointState.h
+++ b/src/sensor_msgs/JointState.h
@@ -149,8 +149,8 @@ namespace sensor_msgs
      return offset;
     }
 
-    virtual const char * getType(const char * type_msg) override { strcpy_P(type_msg, (char *)sensor_msgs_JointState_type);return type_msg; };
-    virtual const char * getMD5(const char * md5_msg) override { strcpy_P(md5_msg, (char *)sensor_msgs_JointState_md5);return md5_msg; };
+    virtual const char * getType(const char * type_msg) override { strcpy_P((char *)type_msg, (char *)sensor_msgs_JointState_type);return type_msg; };
+    virtual const char * getMD5(const char * md5_msg) override { strcpy_P((char *)md5_msg, (char *)sensor_msgs_JointState_md5);return md5_msg; };
 
   };
 

--- a/src/sensor_msgs/Joy.h
+++ b/src/sensor_msgs/Joy.h
@@ -125,8 +125,8 @@ namespace sensor_msgs
      return offset;
     }
 
-    virtual const char * getType(const char * type_msg) override { strcpy_P(type_msg, (char *)sensor_msgs_Joy_type);return type_msg; };
-    virtual const char * getMD5(const char * md5_msg) override { strcpy_P(md5_msg, (char *)sensor_msgs_Joy_md5);return md5_msg; };
+    virtual const char * getType(const char * type_msg) override { strcpy_P((char *)type_msg, (char *)sensor_msgs_Joy_type);return type_msg; };
+    virtual const char * getMD5(const char * md5_msg) override { strcpy_P((char *)md5_msg, (char *)sensor_msgs_Joy_md5);return md5_msg; };
 
   };
 

--- a/src/sensor_msgs/JoyFeedback.h
+++ b/src/sensor_msgs/JoyFeedback.h
@@ -72,8 +72,8 @@ namespace sensor_msgs
      return offset;
     }
 
-    virtual const char * getType(const char * type_msg) override { strcpy_P(type_msg, (char *)sensor_msgs_JoyFeedback_type);return type_msg; };
-    virtual const char * getMD5(const char * md5_msg) override { strcpy_P(md5_msg, (char *)sensor_msgs_JoyFeedback_md5);return md5_msg; };
+    virtual const char * getType(const char * type_msg) override { strcpy_P((char *)type_msg, (char *)sensor_msgs_JoyFeedback_type);return type_msg; };
+    virtual const char * getMD5(const char * md5_msg) override { strcpy_P((char *)md5_msg, (char *)sensor_msgs_JoyFeedback_md5);return md5_msg; };
 
   };
 

--- a/src/sensor_msgs/JoyFeedbackArray.h
+++ b/src/sensor_msgs/JoyFeedbackArray.h
@@ -57,8 +57,8 @@ namespace sensor_msgs
      return offset;
     }
 
-    virtual const char * getType(const char * type_msg) override { strcpy_P(type_msg, (char *)sensor_msgs_JoyFeedbackArray_type);return type_msg; };
-    virtual const char * getMD5(const char * md5_msg) override { strcpy_P(md5_msg, (char *)sensor_msgs_JoyFeedbackArray_md5);return md5_msg; };
+    virtual const char * getType(const char * type_msg) override { strcpy_P((char *)type_msg, (char *)sensor_msgs_JoyFeedbackArray_type);return type_msg; };
+    virtual const char * getMD5(const char * md5_msg) override { strcpy_P((char *)md5_msg, (char *)sensor_msgs_JoyFeedbackArray_md5);return md5_msg; };
 
   };
 

--- a/src/sensor_msgs/LaserEcho.h
+++ b/src/sensor_msgs/LaserEcho.h
@@ -75,8 +75,8 @@ namespace sensor_msgs
      return offset;
     }
 
-    virtual const char * getType(const char * type_msg) override { strcpy_P(type_msg, (char *)sensor_msgs_LaserEcho_type);return type_msg; };
-    virtual const char * getMD5(const char * md5_msg) override { strcpy_P(md5_msg, (char *)sensor_msgs_LaserEcho_md5);return md5_msg; };
+    virtual const char * getType(const char * type_msg) override { strcpy_P((char *)type_msg, (char *)sensor_msgs_LaserEcho_type);return type_msg; };
+    virtual const char * getMD5(const char * md5_msg) override { strcpy_P((char *)md5_msg, (char *)sensor_msgs_LaserEcho_md5);return md5_msg; };
 
   };
 

--- a/src/sensor_msgs/LaserScan.h
+++ b/src/sensor_msgs/LaserScan.h
@@ -293,8 +293,8 @@ namespace sensor_msgs
      return offset;
     }
 
-    virtual const char * getType(const char * type_msg) override { strcpy_P(type_msg, (char *)sensor_msgs_LaserScan_type);return type_msg; };
-    virtual const char * getMD5(const char * md5_msg) override { strcpy_P(md5_msg, (char *)sensor_msgs_LaserScan_md5);return md5_msg; };
+    virtual const char * getType(const char * type_msg) override { strcpy_P((char *)type_msg, (char *)sensor_msgs_LaserScan_type);return type_msg; };
+    virtual const char * getMD5(const char * md5_msg) override { strcpy_P((char *)md5_msg, (char *)sensor_msgs_LaserScan_md5);return md5_msg; };
 
   };
 

--- a/src/sensor_msgs/MagneticField.h
+++ b/src/sensor_msgs/MagneticField.h
@@ -51,8 +51,8 @@ namespace sensor_msgs
      return offset;
     }
 
-    virtual const char * getType(const char * type_msg) override { strcpy_P(type_msg, (char *)sensor_msgs_MagneticField_type);return type_msg; };
-    virtual const char * getMD5(const char * md5_msg) override { strcpy_P(md5_msg, (char *)sensor_msgs_MagneticField_md5);return md5_msg; };
+    virtual const char * getType(const char * type_msg) override { strcpy_P((char *)type_msg, (char *)sensor_msgs_MagneticField_type);return type_msg; };
+    virtual const char * getMD5(const char * md5_msg) override { strcpy_P((char *)md5_msg, (char *)sensor_msgs_MagneticField_md5);return md5_msg; };
 
   };
 

--- a/src/sensor_msgs/MultiDOFJointState.h
+++ b/src/sensor_msgs/MultiDOFJointState.h
@@ -152,8 +152,8 @@ namespace sensor_msgs
      return offset;
     }
 
-    virtual const char * getType(const char * type_msg) override { strcpy_P(type_msg, (char *)sensor_msgs_MultiDOFJointState_type);return type_msg; };
-    virtual const char * getMD5(const char * md5_msg) override { strcpy_P(md5_msg, (char *)sensor_msgs_MultiDOFJointState_md5);return md5_msg; };
+    virtual const char * getType(const char * type_msg) override { strcpy_P((char *)type_msg, (char *)sensor_msgs_MultiDOFJointState_type);return type_msg; };
+    virtual const char * getMD5(const char * md5_msg) override { strcpy_P((char *)md5_msg, (char *)sensor_msgs_MultiDOFJointState_md5);return md5_msg; };
 
   };
 

--- a/src/sensor_msgs/MultiEchoLaserScan.h
+++ b/src/sensor_msgs/MultiEchoLaserScan.h
@@ -256,8 +256,8 @@ namespace sensor_msgs
      return offset;
     }
 
-    virtual const char * getType(const char * type_msg) override { strcpy_P(type_msg, (char *)sensor_msgs_MultiEchoLaserScan_type);return type_msg; };
-    virtual const char * getMD5(const char * md5_msg) override { strcpy_P(md5_msg, (char *)sensor_msgs_MultiEchoLaserScan_md5);return md5_msg; };
+    virtual const char * getType(const char * type_msg) override { strcpy_P((char *)type_msg, (char *)sensor_msgs_MultiEchoLaserScan_type);return type_msg; };
+    virtual const char * getMD5(const char * md5_msg) override { strcpy_P((char *)md5_msg, (char *)sensor_msgs_MultiEchoLaserScan_md5);return md5_msg; };
 
   };
 

--- a/src/sensor_msgs/NavSatFix.h
+++ b/src/sensor_msgs/NavSatFix.h
@@ -77,8 +77,8 @@ namespace sensor_msgs
      return offset;
     }
 
-    virtual const char * getType(const char * type_msg) override { strcpy_P(type_msg, (char *)sensor_msgs_NavSatFix_type);return type_msg; };
-    virtual const char * getMD5(const char * md5_msg) override { strcpy_P(md5_msg, (char *)sensor_msgs_NavSatFix_md5);return md5_msg; };
+    virtual const char * getType(const char * type_msg) override { strcpy_P((char *)type_msg, (char *)sensor_msgs_NavSatFix_type);return type_msg; };
+    virtual const char * getMD5(const char * md5_msg) override { strcpy_P((char *)md5_msg, (char *)sensor_msgs_NavSatFix_md5);return md5_msg; };
 
   };
 

--- a/src/sensor_msgs/NavSatStatus.h
+++ b/src/sensor_msgs/NavSatStatus.h
@@ -66,8 +66,8 @@ namespace sensor_msgs
      return offset;
     }
 
-    virtual const char * getType(const char * type_msg) override { strcpy_P(type_msg, (char *)sensor_msgs_NavSatStatus_type);return type_msg; };
-    virtual const char * getMD5(const char * md5_msg) override { strcpy_P(md5_msg, (char *)sensor_msgs_NavSatStatus_md5);return md5_msg; };
+    virtual const char * getType(const char * type_msg) override { strcpy_P((char *)type_msg, (char *)sensor_msgs_NavSatStatus_type);return type_msg; };
+    virtual const char * getMD5(const char * md5_msg) override { strcpy_P((char *)md5_msg, (char *)sensor_msgs_NavSatStatus_md5);return md5_msg; };
 
   };
 

--- a/src/sensor_msgs/PointCloud.h
+++ b/src/sensor_msgs/PointCloud.h
@@ -89,8 +89,8 @@ namespace sensor_msgs
      return offset;
     }
 
-    virtual const char * getType(const char * type_msg) override { strcpy_P(type_msg, (char *)sensor_msgs_PointCloud_type);return type_msg; };
-    virtual const char * getMD5(const char * md5_msg) override { strcpy_P(md5_msg, (char *)sensor_msgs_PointCloud_md5);return md5_msg; };
+    virtual const char * getType(const char * type_msg) override { strcpy_P((char *)type_msg, (char *)sensor_msgs_PointCloud_type);return type_msg; };
+    virtual const char * getMD5(const char * md5_msg) override { strcpy_P((char *)md5_msg, (char *)sensor_msgs_PointCloud_md5);return md5_msg; };
 
   };
 

--- a/src/sensor_msgs/PointCloud2.h
+++ b/src/sensor_msgs/PointCloud2.h
@@ -178,8 +178,8 @@ namespace sensor_msgs
      return offset;
     }
 
-    virtual const char * getType(const char * type_msg) override { strcpy_P(type_msg, (char *)sensor_msgs_PointCloud2_type);return type_msg; };
-    virtual const char * getMD5(const char * md5_msg) override { strcpy_P(md5_msg, (char *)sensor_msgs_PointCloud2_md5);return md5_msg; };
+    virtual const char * getType(const char * type_msg) override { strcpy_P((char *)type_msg, (char *)sensor_msgs_PointCloud2_type);return type_msg; };
+    virtual const char * getMD5(const char * md5_msg) override { strcpy_P((char *)md5_msg, (char *)sensor_msgs_PointCloud2_md5);return md5_msg; };
 
   };
 

--- a/src/sensor_msgs/PointField.h
+++ b/src/sensor_msgs/PointField.h
@@ -89,8 +89,8 @@ namespace sensor_msgs
      return offset;
     }
 
-    virtual const char * getType(const char * type_msg) override { strcpy_P(type_msg, (char *)sensor_msgs_PointField_type);return type_msg; };
-    virtual const char * getMD5(const char * md5_msg) override { strcpy_P(md5_msg, (char *)sensor_msgs_PointField_md5);return md5_msg; };
+    virtual const char * getType(const char * type_msg) override { strcpy_P((char *)type_msg, (char *)sensor_msgs_PointField_type);return type_msg; };
+    virtual const char * getMD5(const char * md5_msg) override { strcpy_P((char *)md5_msg, (char *)sensor_msgs_PointField_md5);return md5_msg; };
 
   };
 

--- a/src/sensor_msgs/Range.h
+++ b/src/sensor_msgs/Range.h
@@ -142,8 +142,8 @@ namespace sensor_msgs
      return offset;
     }
 
-    virtual const char * getType(const char * type_msg) override { strcpy_P(type_msg, (char *)sensor_msgs_Range_type);return type_msg; };
-    virtual const char * getMD5(const char * md5_msg) override { strcpy_P(md5_msg, (char *)sensor_msgs_Range_md5);return md5_msg; };
+    virtual const char * getType(const char * type_msg) override { strcpy_P((char *)type_msg, (char *)sensor_msgs_Range_type);return type_msg; };
+    virtual const char * getMD5(const char * md5_msg) override { strcpy_P((char *)md5_msg, (char *)sensor_msgs_Range_md5);return md5_msg; };
 
   };
 

--- a/src/sensor_msgs/RegionOfInterest.h
+++ b/src/sensor_msgs/RegionOfInterest.h
@@ -101,8 +101,8 @@ namespace sensor_msgs
      return offset;
     }
 
-    virtual const char * getType(const char * type_msg) override { strcpy_P(type_msg, (char *)sensor_msgs_RegionOfInterest_type);return type_msg; };
-    virtual const char * getMD5(const char * md5_msg) override { strcpy_P(md5_msg, (char *)sensor_msgs_RegionOfInterest_md5);return md5_msg; };
+    virtual const char * getType(const char * type_msg) override { strcpy_P((char *)type_msg, (char *)sensor_msgs_RegionOfInterest_type);return type_msg; };
+    virtual const char * getMD5(const char * md5_msg) override { strcpy_P((char *)md5_msg, (char *)sensor_msgs_RegionOfInterest_md5);return md5_msg; };
 
   };
 

--- a/src/sensor_msgs/RelativeHumidity.h
+++ b/src/sensor_msgs/RelativeHumidity.h
@@ -47,8 +47,8 @@ namespace sensor_msgs
      return offset;
     }
 
-    virtual const char * getType(const char * type_msg) override { strcpy_P(type_msg, (char *)sensor_msgs_RelativeHumidity_type);return type_msg; };
-    virtual const char * getMD5(const char * md5_msg) override { strcpy_P(md5_msg, (char *)sensor_msgs_RelativeHumidity_md5);return md5_msg; };
+    virtual const char * getType(const char * type_msg) override { strcpy_P((char *)type_msg, (char *)sensor_msgs_RelativeHumidity_type);return type_msg; };
+    virtual const char * getMD5(const char * md5_msg) override { strcpy_P((char *)md5_msg, (char *)sensor_msgs_RelativeHumidity_md5);return md5_msg; };
 
   };
 

--- a/src/sensor_msgs/SetCameraInfo.h
+++ b/src/sensor_msgs/SetCameraInfo.h
@@ -38,8 +38,8 @@ static const char SETCAMERAINFO[] PROGMEM= "sensor_msgs/SetCameraInfo";
      return offset;
     }
 
-    virtual const char * getType(const char * type_msg) override { strcpy_P(type_msg, (char *)SETCAMERAINFO);return type_msg; };
-    virtual const char * getMD5(const char * md5_msg) override { strcpy_P(md5_msg, (char *)sensor_msgs_SetCameraInfoRequest_md5);return md5_msg; };
+    virtual const char * getType(const char * type_msg) override { strcpy_P((char *)type_msg, (char *)SETCAMERAINFO);return type_msg; };
+    virtual const char * getMD5(const char * md5_msg) override { strcpy_P((char *)md5_msg, (char *)sensor_msgs_SetCameraInfoRequest_md5);return md5_msg; };
 
   };
 
@@ -100,8 +100,8 @@ static const char SETCAMERAINFO[] PROGMEM= "sensor_msgs/SetCameraInfo";
      return offset;
     }
 
-    virtual const char * getType(const char * type_msg) override { strcpy_P(type_msg, (char *)SETCAMERAINFO);return type_msg; };
-    virtual const char * getMD5(const char * md5_msg) override { strcpy_P(md5_msg, (char *)sensor_msgs_SetCameraInfoResponse_md5);return md5_msg; };
+    virtual const char * getType(const char * type_msg) override { strcpy_P((char *)type_msg, (char *)SETCAMERAINFO);return type_msg; };
+    virtual const char * getMD5(const char * md5_msg) override { strcpy_P((char *)md5_msg, (char *)sensor_msgs_SetCameraInfoResponse_md5);return md5_msg; };
 
   };
 

--- a/src/sensor_msgs/Temperature.h
+++ b/src/sensor_msgs/Temperature.h
@@ -47,8 +47,8 @@ namespace sensor_msgs
      return offset;
     }
 
-    virtual const char * getType(const char * type_msg) override { strcpy_P(type_msg, (char *)sensor_msgs_Temperature_type);return type_msg; };
-    virtual const char * getMD5(const char * md5_msg) override { strcpy_P(md5_msg, (char *)sensor_msgs_Temperature_md5);return md5_msg; };
+    virtual const char * getType(const char * type_msg) override { strcpy_P((char *)type_msg, (char *)sensor_msgs_Temperature_type);return type_msg; };
+    virtual const char * getMD5(const char * md5_msg) override { strcpy_P((char *)md5_msg, (char *)sensor_msgs_Temperature_md5);return md5_msg; };
 
   };
 

--- a/src/sensor_msgs/TimeReference.h
+++ b/src/sensor_msgs/TimeReference.h
@@ -78,8 +78,8 @@ namespace sensor_msgs
      return offset;
     }
 
-    virtual const char * getType(const char * type_msg) override { strcpy_P(type_msg, (char *)sensor_msgs_TimeReference_type);return type_msg; };
-    virtual const char * getMD5(const char * md5_msg) override { strcpy_P(md5_msg, (char *)sensor_msgs_TimeReference_md5);return md5_msg; };
+    virtual const char * getType(const char * type_msg) override { strcpy_P((char *)type_msg, (char *)sensor_msgs_TimeReference_type);return type_msg; };
+    virtual const char * getMD5(const char * md5_msg) override { strcpy_P((char *)md5_msg, (char *)sensor_msgs_TimeReference_md5);return md5_msg; };
 
   };
 

--- a/src/shape_msgs/Mesh.h
+++ b/src/shape_msgs/Mesh.h
@@ -83,8 +83,8 @@ namespace shape_msgs
      return offset;
     }
 
-    virtual const char * getType(const char * type_msg) override { strcpy_P(type_msg, (char *)shape_msgs_Mesh_type);return type_msg; };
-    virtual const char * getMD5(const char * md5_msg) override { strcpy_P(md5_msg, (char *)shape_msgs_Mesh_md5);return md5_msg; };
+    virtual const char * getType(const char * type_msg) override { strcpy_P((char *)type_msg, (char *)shape_msgs_Mesh_type);return type_msg; };
+    virtual const char * getMD5(const char * md5_msg) override { strcpy_P((char *)md5_msg, (char *)shape_msgs_Mesh_md5);return md5_msg; };
 
   };
 

--- a/src/shape_msgs/MeshTriangle.h
+++ b/src/shape_msgs/MeshTriangle.h
@@ -47,8 +47,8 @@ namespace shape_msgs
      return offset;
     }
 
-    virtual const char * getType(const char * type_msg) override { strcpy_P(type_msg, (char *)shape_msgs_MeshTriangle_type);return type_msg; };
-    virtual const char * getMD5(const char * md5_msg) override { strcpy_P(md5_msg, (char *)shape_msgs_MeshTriangle_md5);return md5_msg; };
+    virtual const char * getType(const char * type_msg) override { strcpy_P((char *)type_msg, (char *)shape_msgs_MeshTriangle_type);return type_msg; };
+    virtual const char * getMD5(const char * md5_msg) override { strcpy_P((char *)md5_msg, (char *)shape_msgs_MeshTriangle_md5);return md5_msg; };
 
   };
 

--- a/src/shape_msgs/Plane.h
+++ b/src/shape_msgs/Plane.h
@@ -39,8 +39,8 @@ namespace shape_msgs
      return offset;
     }
 
-    virtual const char * getType(const char * type_msg) override { strcpy_P(type_msg, (char *)shape_msgs_Plane_type);return type_msg; };
-    virtual const char * getMD5(const char * md5_msg) override { strcpy_P(md5_msg, (char *)shape_msgs_Plane_md5);return md5_msg; };
+    virtual const char * getType(const char * type_msg) override { strcpy_P((char *)type_msg, (char *)shape_msgs_Plane_type);return type_msg; };
+    virtual const char * getMD5(const char * md5_msg) override { strcpy_P((char *)md5_msg, (char *)shape_msgs_Plane_md5);return md5_msg; };
 
   };
 

--- a/src/shape_msgs/SolidPrimitive.h
+++ b/src/shape_msgs/SolidPrimitive.h
@@ -75,8 +75,8 @@ namespace shape_msgs
      return offset;
     }
 
-    virtual const char * getType(const char * type_msg) override { strcpy_P(type_msg, (char *)shape_msgs_SolidPrimitive_type);return type_msg; };
-    virtual const char * getMD5(const char * md5_msg) override { strcpy_P(md5_msg, (char *)shape_msgs_SolidPrimitive_md5);return md5_msg; };
+    virtual const char * getType(const char * type_msg) override { strcpy_P((char *)type_msg, (char *)shape_msgs_SolidPrimitive_type);return type_msg; };
+    virtual const char * getMD5(const char * md5_msg) override { strcpy_P((char *)md5_msg, (char *)shape_msgs_SolidPrimitive_md5);return md5_msg; };
 
   };
 

--- a/src/std_msgs/Bool.h
+++ b/src/std_msgs/Bool.h
@@ -49,8 +49,8 @@ namespace std_msgs
      return offset;
     }
 
-    virtual const char * getType(const char * type_msg) override { strcpy_P(type_msg, (char *)std_msgs_Bool_type);return type_msg; };
-    virtual const char * getMD5(const char * md5_msg) override { strcpy_P(md5_msg, (char *)std_msgs_Bool_md5);return md5_msg; };
+    virtual const char * getType(const char * type_msg) override { strcpy_P((char *)type_msg, (char *)std_msgs_Bool_type);return type_msg; };
+    virtual const char * getMD5(const char * md5_msg) override { strcpy_P((char *)md5_msg, (char *)std_msgs_Bool_md5);return md5_msg; };
 
   };
 

--- a/src/std_msgs/Byte.h
+++ b/src/std_msgs/Byte.h
@@ -49,8 +49,8 @@ namespace std_msgs
      return offset;
     }
 
-    virtual const char * getType(const char * type_msg) override { strcpy_P(type_msg, (char *)std_msgs_Byte_type);return type_msg; };
-    virtual const char * getMD5(const char * md5_msg) override { strcpy_P(md5_msg, (char *)std_msgs_Byte_md5);return md5_msg; };
+    virtual const char * getType(const char * type_msg) override { strcpy_P((char *)type_msg, (char *)std_msgs_Byte_type);return type_msg; };
+    virtual const char * getMD5(const char * md5_msg) override { strcpy_P((char *)md5_msg, (char *)std_msgs_Byte_md5);return md5_msg; };
 
   };
 

--- a/src/std_msgs/ByteMultiArray.h
+++ b/src/std_msgs/ByteMultiArray.h
@@ -75,8 +75,8 @@ namespace std_msgs
      return offset;
     }
 
-    virtual const char * getType(const char * type_msg) override { strcpy_P(type_msg, (char *)std_msgs_ByteMultiArray_type);return type_msg; };
-    virtual const char * getMD5(const char * md5_msg) override { strcpy_P(md5_msg, (char *)std_msgs_ByteMultiArray_md5);return md5_msg; };
+    virtual const char * getType(const char * type_msg) override { strcpy_P((char *)type_msg, (char *)std_msgs_ByteMultiArray_type);return type_msg; };
+    virtual const char * getMD5(const char * md5_msg) override { strcpy_P((char *)md5_msg, (char *)std_msgs_ByteMultiArray_md5);return md5_msg; };
 
   };
 

--- a/src/std_msgs/Char.h
+++ b/src/std_msgs/Char.h
@@ -38,8 +38,8 @@ namespace std_msgs
      return offset;
     }
 
-    virtual const char * getType(const char * type_msg) override { strcpy_P(type_msg, (char *)std_msgs_Char_type);return type_msg; };
-    virtual const char * getMD5(const char * md5_msg) override { strcpy_P(md5_msg, (char *)std_msgs_Char_md5);return md5_msg; };
+    virtual const char * getType(const char * type_msg) override { strcpy_P((char *)type_msg, (char *)std_msgs_Char_type);return type_msg; };
+    virtual const char * getMD5(const char * md5_msg) override { strcpy_P((char *)md5_msg, (char *)std_msgs_Char_md5);return md5_msg; };
 
   };
 

--- a/src/std_msgs/ColorRGBA.h
+++ b/src/std_msgs/ColorRGBA.h
@@ -127,8 +127,8 @@ namespace std_msgs
      return offset;
     }
 
-    virtual const char * getType(const char * type_msg) override { strcpy_P(type_msg, (char *)std_msgs_ColorRGBA_type);return type_msg; };
-    virtual const char * getMD5(const char * md5_msg) override { strcpy_P(md5_msg, (char *)std_msgs_ColorRGBA_md5);return md5_msg; };
+    virtual const char * getType(const char * type_msg) override { strcpy_P((char *)type_msg, (char *)std_msgs_ColorRGBA_type);return type_msg; };
+    virtual const char * getMD5(const char * md5_msg) override { strcpy_P((char *)md5_msg, (char *)std_msgs_ColorRGBA_md5);return md5_msg; };
 
   };
 

--- a/src/std_msgs/Duration.h
+++ b/src/std_msgs/Duration.h
@@ -55,8 +55,8 @@ namespace std_msgs
      return offset;
     }
 
-    virtual const char * getType(const char * type_msg) override { strcpy_P(type_msg, (char *)std_msgs_Duration_type);return type_msg; };
-    virtual const char * getMD5(const char * md5_msg) override { strcpy_P(md5_msg, (char *)std_msgs_Duration_md5);return md5_msg; };
+    virtual const char * getType(const char * type_msg) override { strcpy_P((char *)type_msg, (char *)std_msgs_Duration_type);return type_msg; };
+    virtual const char * getMD5(const char * md5_msg) override { strcpy_P((char *)md5_msg, (char *)std_msgs_Duration_md5);return md5_msg; };
 
   };
 

--- a/src/std_msgs/Empty.h
+++ b/src/std_msgs/Empty.h
@@ -31,8 +31,8 @@ namespace std_msgs
      return offset;
     }
 
-    virtual const char * getType(const char * type_msg) override { strcpy_P(type_msg, (char *)std_msgs_Empty_type);return type_msg; };
-    virtual const char * getMD5(const char * md5_msg) override { strcpy_P(md5_msg, (char *)std_msgs_Empty_md5);return md5_msg; };
+    virtual const char * getType(const char * type_msg) override { strcpy_P((char *)type_msg, (char *)std_msgs_Empty_type);return type_msg; };
+    virtual const char * getMD5(const char * md5_msg) override { strcpy_P((char *)md5_msg, (char *)std_msgs_Empty_md5);return md5_msg; };
 
   };
 

--- a/src/std_msgs/Float32.h
+++ b/src/std_msgs/Float32.h
@@ -55,8 +55,8 @@ namespace std_msgs
      return offset;
     }
 
-    virtual const char * getType(const char * type_msg) override { strcpy_P(type_msg, (char *)std_msgs_Float32_type);return type_msg; };
-    virtual const char * getMD5(const char * md5_msg) override { strcpy_P(md5_msg, (char *)std_msgs_Float32_md5);return md5_msg; };
+    virtual const char * getType(const char * type_msg) override { strcpy_P((char *)type_msg, (char *)std_msgs_Float32_type);return type_msg; };
+    virtual const char * getMD5(const char * md5_msg) override { strcpy_P((char *)md5_msg, (char *)std_msgs_Float32_md5);return md5_msg; };
 
   };
 

--- a/src/std_msgs/Float32MultiArray.h
+++ b/src/std_msgs/Float32MultiArray.h
@@ -81,8 +81,8 @@ namespace std_msgs
      return offset;
     }
 
-    virtual const char * getType(const char * type_msg) override { strcpy_P(type_msg, (char *)std_msgs_Float32MultiArray_type);return type_msg; };
-    virtual const char * getMD5(const char * md5_msg) override { strcpy_P(md5_msg, (char *)std_msgs_Float32MultiArray_md5);return md5_msg; };
+    virtual const char * getType(const char * type_msg) override { strcpy_P((char *)type_msg, (char *)std_msgs_Float32MultiArray_type);return type_msg; };
+    virtual const char * getMD5(const char * md5_msg) override { strcpy_P((char *)md5_msg, (char *)std_msgs_Float32MultiArray_md5);return md5_msg; };
 
   };
 

--- a/src/std_msgs/Float64.h
+++ b/src/std_msgs/Float64.h
@@ -36,8 +36,8 @@ namespace std_msgs
      return offset;
     }
 
-    virtual const char * getType(const char * type_msg) override { strcpy_P(type_msg, (char *)std_msgs_Float64_type);return type_msg; };
-    virtual const char * getMD5(const char * md5_msg) override { strcpy_P(md5_msg, (char *)std_msgs_Float64_md5);return md5_msg; };
+    virtual const char * getType(const char * type_msg) override { strcpy_P((char *)type_msg, (char *)std_msgs_Float64_type);return type_msg; };
+    virtual const char * getMD5(const char * md5_msg) override { strcpy_P((char *)md5_msg, (char *)std_msgs_Float64_md5);return md5_msg; };
 
   };
 

--- a/src/std_msgs/Float64MultiArray.h
+++ b/src/std_msgs/Float64MultiArray.h
@@ -62,8 +62,8 @@ namespace std_msgs
      return offset;
     }
 
-    virtual const char * getType(const char * type_msg) override { strcpy_P(type_msg, (char *)std_msgs_Float64MultiArray_type);return type_msg; };
-    virtual const char * getMD5(const char * md5_msg) override { strcpy_P(md5_msg, (char *)std_msgs_Float64MultiArray_md5);return md5_msg; };
+    virtual const char * getType(const char * type_msg) override { strcpy_P((char *)type_msg, (char *)std_msgs_Float64MultiArray_type);return type_msg; };
+    virtual const char * getMD5(const char * md5_msg) override { strcpy_P((char *)md5_msg, (char *)std_msgs_Float64MultiArray_md5);return md5_msg; };
 
   };
 

--- a/src/std_msgs/Header.h
+++ b/src/std_msgs/Header.h
@@ -85,8 +85,8 @@ namespace std_msgs
      return offset;
     }
 
-    virtual const char * getType(const char * type_msg) override { strcpy_P(type_msg, (char *)std_msgs_Header_type);return type_msg; };
-    virtual const char * getMD5(const char * md5_msg) override { strcpy_P(md5_msg, (char *)std_msgs_Header_md5);return md5_msg; };
+    virtual const char * getType(const char * type_msg) override { strcpy_P((char *)type_msg, (char *)std_msgs_Header_type);return type_msg; };
+    virtual const char * getMD5(const char * md5_msg) override { strcpy_P((char *)md5_msg, (char *)std_msgs_Header_md5);return md5_msg; };
 
   };
 

--- a/src/std_msgs/Int16.h
+++ b/src/std_msgs/Int16.h
@@ -51,8 +51,8 @@ namespace std_msgs
      return offset;
     }
 
-    virtual const char * getType(const char * type_msg) override { strcpy_P(type_msg, (char *)std_msgs_Int16_type);return type_msg; };
-    virtual const char * getMD5(const char * md5_msg) override { strcpy_P(md5_msg, (char *)std_msgs_Int16_md5);return md5_msg; };
+    virtual const char * getType(const char * type_msg) override { strcpy_P((char *)type_msg, (char *)std_msgs_Int16_type);return type_msg; };
+    virtual const char * getMD5(const char * md5_msg) override { strcpy_P((char *)md5_msg, (char *)std_msgs_Int16_md5);return md5_msg; };
 
   };
 

--- a/src/std_msgs/Int16MultiArray.h
+++ b/src/std_msgs/Int16MultiArray.h
@@ -77,8 +77,8 @@ namespace std_msgs
      return offset;
     }
 
-    virtual const char * getType(const char * type_msg) override { strcpy_P(type_msg, (char *)std_msgs_Int16MultiArray_type);return type_msg; };
-    virtual const char * getMD5(const char * md5_msg) override { strcpy_P(md5_msg, (char *)std_msgs_Int16MultiArray_md5);return md5_msg; };
+    virtual const char * getType(const char * type_msg) override { strcpy_P((char *)type_msg, (char *)std_msgs_Int16MultiArray_type);return type_msg; };
+    virtual const char * getMD5(const char * md5_msg) override { strcpy_P((char *)md5_msg, (char *)std_msgs_Int16MultiArray_md5);return md5_msg; };
 
   };
 

--- a/src/std_msgs/Int32.h
+++ b/src/std_msgs/Int32.h
@@ -55,8 +55,8 @@ namespace std_msgs
      return offset;
     }
 
-    virtual const char * getType(const char * type_msg) override { strcpy_P(type_msg, (char *)std_msgs_Int32_type);return type_msg; };
-    virtual const char * getMD5(const char * md5_msg) override { strcpy_P(md5_msg, (char *)std_msgs_Int32_md5);return md5_msg; };
+    virtual const char * getType(const char * type_msg) override { strcpy_P((char *)type_msg, (char *)std_msgs_Int32_type);return type_msg; };
+    virtual const char * getMD5(const char * md5_msg) override { strcpy_P((char *)md5_msg, (char *)std_msgs_Int32_md5);return md5_msg; };
 
   };
 

--- a/src/std_msgs/Int32MultiArray.h
+++ b/src/std_msgs/Int32MultiArray.h
@@ -81,8 +81,8 @@ namespace std_msgs
      return offset;
     }
 
-    virtual const char * getType(const char * type_msg) override { strcpy_P(type_msg, (char *)std_msgs_Int32MultiArray_type);return type_msg; };
-    virtual const char * getMD5(const char * md5_msg) override { strcpy_P(md5_msg, (char *)std_msgs_Int32MultiArray_md5);return md5_msg; };
+    virtual const char * getType(const char * type_msg) override { strcpy_P((char *)type_msg, (char *)std_msgs_Int32MultiArray_type);return type_msg; };
+    virtual const char * getMD5(const char * md5_msg) override { strcpy_P((char *)md5_msg, (char *)std_msgs_Int32MultiArray_md5);return md5_msg; };
 
   };
 

--- a/src/std_msgs/Int64.h
+++ b/src/std_msgs/Int64.h
@@ -63,8 +63,8 @@ namespace std_msgs
      return offset;
     }
 
-    virtual const char * getType(const char * type_msg) override { strcpy_P(type_msg, (char *)std_msgs_Int64_type);return type_msg; };
-    virtual const char * getMD5(const char * md5_msg) override { strcpy_P(md5_msg, (char *)std_msgs_Int64_md5);return md5_msg; };
+    virtual const char * getType(const char * type_msg) override { strcpy_P((char *)type_msg, (char *)std_msgs_Int64_type);return type_msg; };
+    virtual const char * getMD5(const char * md5_msg) override { strcpy_P((char *)md5_msg, (char *)std_msgs_Int64_md5);return md5_msg; };
 
   };
 

--- a/src/std_msgs/Int64MultiArray.h
+++ b/src/std_msgs/Int64MultiArray.h
@@ -89,8 +89,8 @@ namespace std_msgs
      return offset;
     }
 
-    virtual const char * getType(const char * type_msg) override { strcpy_P(type_msg, (char *)std_msgs_Int64MultiArray_type);return type_msg; };
-    virtual const char * getMD5(const char * md5_msg) override { strcpy_P(md5_msg, (char *)std_msgs_Int64MultiArray_md5);return md5_msg; };
+    virtual const char * getType(const char * type_msg) override { strcpy_P((char *)type_msg, (char *)std_msgs_Int64MultiArray_type);return type_msg; };
+    virtual const char * getMD5(const char * md5_msg) override { strcpy_P((char *)md5_msg, (char *)std_msgs_Int64MultiArray_md5);return md5_msg; };
 
   };
 

--- a/src/std_msgs/Int8.h
+++ b/src/std_msgs/Int8.h
@@ -49,8 +49,8 @@ namespace std_msgs
      return offset;
     }
 
-    virtual const char * getType(const char * type_msg) override { strcpy_P(type_msg, (char *)std_msgs_Int8_type);return type_msg; };
-    virtual const char * getMD5(const char * md5_msg) override { strcpy_P(md5_msg, (char *)std_msgs_Int8_md5);return md5_msg; };
+    virtual const char * getType(const char * type_msg) override { strcpy_P((char *)type_msg, (char *)std_msgs_Int8_type);return type_msg; };
+    virtual const char * getMD5(const char * md5_msg) override { strcpy_P((char *)md5_msg, (char *)std_msgs_Int8_md5);return md5_msg; };
 
   };
 

--- a/src/std_msgs/Int8MultiArray.h
+++ b/src/std_msgs/Int8MultiArray.h
@@ -75,8 +75,8 @@ namespace std_msgs
      return offset;
     }
 
-    virtual const char * getType(const char * type_msg) override { strcpy_P(type_msg, (char *)std_msgs_Int8MultiArray_type);return type_msg; };
-    virtual const char * getMD5(const char * md5_msg) override { strcpy_P(md5_msg, (char *)std_msgs_Int8MultiArray_md5);return md5_msg; };
+    virtual const char * getType(const char * type_msg) override { strcpy_P((char *)type_msg, (char *)std_msgs_Int8MultiArray_type);return type_msg; };
+    virtual const char * getMD5(const char * md5_msg) override { strcpy_P((char *)md5_msg, (char *)std_msgs_Int8MultiArray_md5);return md5_msg; };
 
   };
 

--- a/src/std_msgs/MultiArrayDimension.h
+++ b/src/std_msgs/MultiArrayDimension.h
@@ -74,8 +74,8 @@ namespace std_msgs
      return offset;
     }
 
-    virtual const char * getType(const char * type_msg) override { strcpy_P(type_msg, (char *)std_msgs_MultiArrayDimension_type);return type_msg; };
-    virtual const char * getMD5(const char * md5_msg) override { strcpy_P(md5_msg, (char *)std_msgs_MultiArrayDimension_md5);return md5_msg; };
+    virtual const char * getType(const char * type_msg) override { strcpy_P((char *)type_msg, (char *)std_msgs_MultiArrayDimension_type);return type_msg; };
+    virtual const char * getMD5(const char * md5_msg) override { strcpy_P((char *)md5_msg, (char *)std_msgs_MultiArrayDimension_md5);return md5_msg; };
 
   };
 

--- a/src/std_msgs/MultiArrayLayout.h
+++ b/src/std_msgs/MultiArrayLayout.h
@@ -70,8 +70,8 @@ namespace std_msgs
      return offset;
     }
 
-    virtual const char * getType(const char * type_msg) override { strcpy_P(type_msg, (char *)std_msgs_MultiArrayLayout_type);return type_msg; };
-    virtual const char * getMD5(const char * md5_msg) override { strcpy_P(md5_msg, (char *)std_msgs_MultiArrayLayout_md5);return md5_msg; };
+    virtual const char * getType(const char * type_msg) override { strcpy_P((char *)type_msg, (char *)std_msgs_MultiArrayLayout_type);return type_msg; };
+    virtual const char * getMD5(const char * md5_msg) override { strcpy_P((char *)md5_msg, (char *)std_msgs_MultiArrayLayout_md5);return md5_msg; };
 
   };
 

--- a/src/std_msgs/String.h
+++ b/src/std_msgs/String.h
@@ -48,8 +48,8 @@ namespace std_msgs
      return offset;
     }
 
-    virtual const char * getType(const char * type_msg) override { strcpy_P(type_msg, (char *)std_msgs_String_type);return type_msg; };
-    virtual const char * getMD5(const char * md5_msg) override { strcpy_P(md5_msg, (char *)std_msgs_String_md5);return md5_msg; };
+    virtual const char * getType(const char * type_msg) override { strcpy_P((char *)type_msg, (char *)std_msgs_String_type);return type_msg; };
+    virtual const char * getMD5(const char * md5_msg) override { strcpy_P((char *)md5_msg, (char *)std_msgs_String_md5);return md5_msg; };
 
   };
 

--- a/src/std_msgs/Time.h
+++ b/src/std_msgs/Time.h
@@ -55,8 +55,8 @@ namespace std_msgs
      return offset;
     }
 
-    virtual const char * getType(const char * type_msg) override { strcpy_P(type_msg, (char *)std_msgs_Time_type);return type_msg; };
-    virtual const char * getMD5(const char * md5_msg) override { strcpy_P(md5_msg, (char *)std_msgs_Time_md5);return md5_msg; };
+    virtual const char * getType(const char * type_msg) override { strcpy_P((char *)type_msg, (char *)std_msgs_Time_type);return type_msg; };
+    virtual const char * getMD5(const char * md5_msg) override { strcpy_P((char *)md5_msg, (char *)std_msgs_Time_md5);return md5_msg; };
 
   };
 

--- a/src/std_msgs/UInt16.h
+++ b/src/std_msgs/UInt16.h
@@ -40,8 +40,8 @@ namespace std_msgs
      return offset;
     }
 
-    virtual const char * getType(const char * type_msg) override { strcpy_P(type_msg, (char *)std_msgs_UInt16_type);return type_msg; };
-    virtual const char * getMD5(const char * md5_msg) override { strcpy_P(md5_msg, (char *)std_msgs_UInt16_md5);return md5_msg; };
+    virtual const char * getType(const char * type_msg) override { strcpy_P((char *)type_msg, (char *)std_msgs_UInt16_type);return type_msg; };
+    virtual const char * getMD5(const char * md5_msg) override { strcpy_P((char *)md5_msg, (char *)std_msgs_UInt16_md5);return md5_msg; };
 
   };
 

--- a/src/std_msgs/UInt16MultiArray.h
+++ b/src/std_msgs/UInt16MultiArray.h
@@ -66,8 +66,8 @@ namespace std_msgs
      return offset;
     }
 
-    virtual const char * getType(const char * type_msg) override { strcpy_P(type_msg, (char *)std_msgs_UInt16MultiArray_type);return type_msg; };
-    virtual const char * getMD5(const char * md5_msg) override { strcpy_P(md5_msg, (char *)std_msgs_UInt16MultiArray_md5);return md5_msg; };
+    virtual const char * getType(const char * type_msg) override { strcpy_P((char *)type_msg, (char *)std_msgs_UInt16MultiArray_type);return type_msg; };
+    virtual const char * getMD5(const char * md5_msg) override { strcpy_P((char *)md5_msg, (char *)std_msgs_UInt16MultiArray_md5);return md5_msg; };
 
   };
 

--- a/src/std_msgs/UInt32.h
+++ b/src/std_msgs/UInt32.h
@@ -44,8 +44,8 @@ namespace std_msgs
      return offset;
     }
 
-    virtual const char * getType(const char * type_msg) override { strcpy_P(type_msg, (char *)std_msgs_UInt32_type);return type_msg; };
-    virtual const char * getMD5(const char * md5_msg) override { strcpy_P(md5_msg, (char *)std_msgs_UInt32_md5);return md5_msg; };
+    virtual const char * getType(const char * type_msg) override { strcpy_P((char *)type_msg, (char *)std_msgs_UInt32_type);return type_msg; };
+    virtual const char * getMD5(const char * md5_msg) override { strcpy_P((char *)md5_msg, (char *)std_msgs_UInt32_md5);return md5_msg; };
 
   };
 

--- a/src/std_msgs/UInt32MultiArray.h
+++ b/src/std_msgs/UInt32MultiArray.h
@@ -70,8 +70,8 @@ namespace std_msgs
      return offset;
     }
 
-    virtual const char * getType(const char * type_msg) override { strcpy_P(type_msg, (char *)std_msgs_UInt32MultiArray_type);return type_msg; };
-    virtual const char * getMD5(const char * md5_msg) override { strcpy_P(md5_msg, (char *)std_msgs_UInt32MultiArray_md5);return md5_msg; };
+    virtual const char * getType(const char * type_msg) override { strcpy_P((char *)type_msg, (char *)std_msgs_UInt32MultiArray_type);return type_msg; };
+    virtual const char * getMD5(const char * md5_msg) override { strcpy_P((char *)md5_msg, (char *)std_msgs_UInt32MultiArray_md5);return md5_msg; };
 
   };
 

--- a/src/std_msgs/UInt64.h
+++ b/src/std_msgs/UInt64.h
@@ -52,8 +52,8 @@ namespace std_msgs
      return offset;
     }
 
-    virtual const char * getType(const char * type_msg) override { strcpy_P(type_msg, (char *)std_msgs_UInt64_type);return type_msg; };
-    virtual const char * getMD5(const char * md5_msg) override { strcpy_P(md5_msg, (char *)std_msgs_UInt64_md5);return md5_msg; };
+    virtual const char * getType(const char * type_msg) override { strcpy_P((char *)type_msg, (char *)std_msgs_UInt64_type);return type_msg; };
+    virtual const char * getMD5(const char * md5_msg) override { strcpy_P((char *)md5_msg, (char *)std_msgs_UInt64_md5);return md5_msg; };
 
   };
 

--- a/src/std_msgs/UInt64MultiArray.h
+++ b/src/std_msgs/UInt64MultiArray.h
@@ -78,8 +78,8 @@ namespace std_msgs
      return offset;
     }
 
-    virtual const char * getType(const char * type_msg) override { strcpy_P(type_msg, (char *)std_msgs_UInt64MultiArray_type);return type_msg; };
-    virtual const char * getMD5(const char * md5_msg) override { strcpy_P(md5_msg, (char *)std_msgs_UInt64MultiArray_md5);return md5_msg; };
+    virtual const char * getType(const char * type_msg) override { strcpy_P((char *)type_msg, (char *)std_msgs_UInt64MultiArray_type);return type_msg; };
+    virtual const char * getMD5(const char * md5_msg) override { strcpy_P((char *)md5_msg, (char *)std_msgs_UInt64MultiArray_md5);return md5_msg; };
 
   };
 

--- a/src/std_msgs/UInt8.h
+++ b/src/std_msgs/UInt8.h
@@ -38,8 +38,8 @@ namespace std_msgs
      return offset;
     }
 
-    virtual const char * getType(const char * type_msg) override { strcpy_P(type_msg, (char *)std_msgs_UInt8_type);return type_msg; };
-    virtual const char * getMD5(const char * md5_msg) override { strcpy_P(md5_msg, (char *)std_msgs_UInt8_md5);return md5_msg; };
+    virtual const char * getType(const char * type_msg) override { strcpy_P((char *)type_msg, (char *)std_msgs_UInt8_type);return type_msg; };
+    virtual const char * getMD5(const char * md5_msg) override { strcpy_P((char *)md5_msg, (char *)std_msgs_UInt8_md5);return md5_msg; };
 
   };
 

--- a/src/std_msgs/UInt8MultiArray.h
+++ b/src/std_msgs/UInt8MultiArray.h
@@ -64,8 +64,8 @@ namespace std_msgs
      return offset;
     }
 
-    virtual const char * getType(const char * type_msg) override { strcpy_P(type_msg, (char *)std_msgs_UInt8MultiArray_type);return type_msg; };
-    virtual const char * getMD5(const char * md5_msg) override { strcpy_P(md5_msg, (char *)std_msgs_UInt8MultiArray_md5);return md5_msg; };
+    virtual const char * getType(const char * type_msg) override { strcpy_P((char *)type_msg, (char *)std_msgs_UInt8MultiArray_type);return type_msg; };
+    virtual const char * getMD5(const char * md5_msg) override { strcpy_P((char *)md5_msg, (char *)std_msgs_UInt8MultiArray_md5);return md5_msg; };
 
   };
 

--- a/src/std_srvs/Empty.h
+++ b/src/std_srvs/Empty.h
@@ -32,8 +32,8 @@ static const char EMPTY[] PROGMEM= "std_srvs/Empty";
      return offset;
     }
 
-    virtual const char * getType(const char * type_msg) override { strcpy_P(type_msg, (char *)EMPTY);return type_msg; };
-    virtual const char * getMD5(const char * md5_msg) override { strcpy_P(md5_msg, (char *)std_srvs_EmptyRequest_md5);return md5_msg; };
+    virtual const char * getType(const char * type_msg) override { strcpy_P((char *)type_msg, (char *)EMPTY);return type_msg; };
+    virtual const char * getMD5(const char * md5_msg) override { strcpy_P((char *)md5_msg, (char *)std_srvs_EmptyRequest_md5);return md5_msg; };
 
   };
 
@@ -59,8 +59,8 @@ static const char EMPTY[] PROGMEM= "std_srvs/Empty";
      return offset;
     }
 
-    virtual const char * getType(const char * type_msg) override { strcpy_P(type_msg, (char *)EMPTY);return type_msg; };
-    virtual const char * getMD5(const char * md5_msg) override { strcpy_P(md5_msg, (char *)std_srvs_EmptyResponse_md5);return md5_msg; };
+    virtual const char * getType(const char * type_msg) override { strcpy_P((char *)type_msg, (char *)EMPTY);return type_msg; };
+    virtual const char * getMD5(const char * md5_msg) override { strcpy_P((char *)md5_msg, (char *)std_srvs_EmptyResponse_md5);return md5_msg; };
 
   };
 

--- a/src/std_srvs/SetBool.h
+++ b/src/std_srvs/SetBool.h
@@ -50,8 +50,8 @@ static const char SETBOOL[] PROGMEM= "std_srvs/SetBool";
      return offset;
     }
 
-    virtual const char * getType(const char * type_msg) override { strcpy_P(type_msg, (char *)SETBOOL);return type_msg; };
-    virtual const char * getMD5(const char * md5_msg) override { strcpy_P(md5_msg, (char *)std_srvs_SetBoolRequest_md5);return md5_msg; };
+    virtual const char * getType(const char * type_msg) override { strcpy_P((char *)type_msg, (char *)SETBOOL);return type_msg; };
+    virtual const char * getMD5(const char * md5_msg) override { strcpy_P((char *)md5_msg, (char *)std_srvs_SetBoolRequest_md5);return md5_msg; };
 
   };
 
@@ -112,8 +112,8 @@ static const char SETBOOL[] PROGMEM= "std_srvs/SetBool";
      return offset;
     }
 
-    virtual const char * getType(const char * type_msg) override { strcpy_P(type_msg, (char *)SETBOOL);return type_msg; };
-    virtual const char * getMD5(const char * md5_msg) override { strcpy_P(md5_msg, (char *)std_srvs_SetBoolResponse_md5);return md5_msg; };
+    virtual const char * getType(const char * type_msg) override { strcpy_P((char *)type_msg, (char *)SETBOOL);return type_msg; };
+    virtual const char * getMD5(const char * md5_msg) override { strcpy_P((char *)md5_msg, (char *)std_srvs_SetBoolResponse_md5);return md5_msg; };
 
   };
 

--- a/src/std_srvs/Trigger.h
+++ b/src/std_srvs/Trigger.h
@@ -32,8 +32,8 @@ static const char TRIGGER[] PROGMEM= "std_srvs/Trigger";
      return offset;
     }
 
-    virtual const char * getType(const char * type_msg) override { strcpy_P(type_msg, (char *)TRIGGER);return type_msg; };
-    virtual const char * getMD5(const char * md5_msg) override { strcpy_P(md5_msg, (char *)std_srvs_TriggerRequest_md5);return md5_msg; };
+    virtual const char * getType(const char * type_msg) override { strcpy_P((char *)type_msg, (char *)TRIGGER);return type_msg; };
+    virtual const char * getMD5(const char * md5_msg) override { strcpy_P((char *)md5_msg, (char *)std_srvs_TriggerRequest_md5);return md5_msg; };
 
   };
 
@@ -94,8 +94,8 @@ static const char TRIGGER[] PROGMEM= "std_srvs/Trigger";
      return offset;
     }
 
-    virtual const char * getType(const char * type_msg) override { strcpy_P(type_msg, (char *)TRIGGER);return type_msg; };
-    virtual const char * getMD5(const char * md5_msg) override { strcpy_P(md5_msg, (char *)std_srvs_TriggerResponse_md5);return md5_msg; };
+    virtual const char * getType(const char * type_msg) override { strcpy_P((char *)type_msg, (char *)TRIGGER);return type_msg; };
+    virtual const char * getMD5(const char * md5_msg) override { strcpy_P((char *)md5_msg, (char *)std_srvs_TriggerResponse_md5);return md5_msg; };
 
   };
 

--- a/src/stereo_msgs/DisparityImage.h
+++ b/src/stereo_msgs/DisparityImage.h
@@ -169,8 +169,8 @@ namespace stereo_msgs
      return offset;
     }
 
-    virtual const char * getType(const char * type_msg) override { strcpy_P(type_msg, (char *)stereo_msgs_DisparityImage_type);return type_msg; };
-    virtual const char * getMD5(const char * md5_msg) override { strcpy_P(md5_msg, (char *)stereo_msgs_DisparityImage_md5);return md5_msg; };
+    virtual const char * getType(const char * type_msg) override { strcpy_P((char *)type_msg, (char *)stereo_msgs_DisparityImage_type);return type_msg; };
+    virtual const char * getMD5(const char * md5_msg) override { strcpy_P((char *)md5_msg, (char *)stereo_msgs_DisparityImage_md5);return md5_msg; };
 
   };
 

--- a/src/tf/FrameGraph.h
+++ b/src/tf/FrameGraph.h
@@ -32,8 +32,8 @@ static const char FRAMEGRAPH[] PROGMEM= "tf/FrameGraph";
      return offset;
     }
 
-    virtual const char * getType(const char * type_msg) override { strcpy_P(type_msg, (char *)FRAMEGRAPH);return type_msg; };
-    virtual const char * getMD5(const char * md5_msg) override { strcpy_P(md5_msg, (char *)tf_FrameGraphRequest_md5);return md5_msg; };
+    virtual const char * getType(const char * type_msg) override { strcpy_P((char *)type_msg, (char *)FRAMEGRAPH);return type_msg; };
+    virtual const char * getMD5(const char * md5_msg) override { strcpy_P((char *)md5_msg, (char *)tf_FrameGraphRequest_md5);return md5_msg; };
 
   };
 
@@ -76,8 +76,8 @@ static const char FRAMEGRAPH[] PROGMEM= "tf/FrameGraph";
      return offset;
     }
 
-    virtual const char * getType(const char * type_msg) override { strcpy_P(type_msg, (char *)FRAMEGRAPH);return type_msg; };
-    virtual const char * getMD5(const char * md5_msg) override { strcpy_P(md5_msg, (char *)tf_FrameGraphResponse_md5);return md5_msg; };
+    virtual const char * getType(const char * type_msg) override { strcpy_P((char *)type_msg, (char *)FRAMEGRAPH);return type_msg; };
+    virtual const char * getMD5(const char * md5_msg) override { strcpy_P((char *)md5_msg, (char *)tf_FrameGraphResponse_md5);return md5_msg; };
 
   };
 

--- a/src/tf/tfMessage.h
+++ b/src/tf/tfMessage.h
@@ -57,8 +57,8 @@ namespace tf
      return offset;
     }
 
-    virtual const char * getType(const char * type_msg) override { strcpy_P(type_msg, (char *)tf_tfMessage_type);return type_msg; };
-    virtual const char * getMD5(const char * md5_msg) override { strcpy_P(md5_msg, (char *)tf_tfMessage_md5);return md5_msg; };
+    virtual const char * getType(const char * type_msg) override { strcpy_P((char *)type_msg, (char *)tf_tfMessage_type);return type_msg; };
+    virtual const char * getMD5(const char * md5_msg) override { strcpy_P((char *)md5_msg, (char *)tf_tfMessage_md5);return md5_msg; };
 
   };
 

--- a/src/tf2_msgs/FrameGraph.h
+++ b/src/tf2_msgs/FrameGraph.h
@@ -32,8 +32,8 @@ static const char FRAMEGRAPH[] PROGMEM= "tf2_msgs/FrameGraph";
      return offset;
     }
 
-    virtual const char * getType(const char * type_msg) override { strcpy_P(type_msg, (char *)FRAMEGRAPH);return type_msg; };
-    virtual const char * getMD5(const char * md5_msg) override { strcpy_P(md5_msg, (char *)tf2_msgs_FrameGraphRequest_md5);return md5_msg; };
+    virtual const char * getType(const char * type_msg) override { strcpy_P((char *)type_msg, (char *)FRAMEGRAPH);return type_msg; };
+    virtual const char * getMD5(const char * md5_msg) override { strcpy_P((char *)md5_msg, (char *)tf2_msgs_FrameGraphRequest_md5);return md5_msg; };
 
   };
 
@@ -76,8 +76,8 @@ static const char FRAMEGRAPH[] PROGMEM= "tf2_msgs/FrameGraph";
      return offset;
     }
 
-    virtual const char * getType(const char * type_msg) override { strcpy_P(type_msg, (char *)FRAMEGRAPH);return type_msg; };
-    virtual const char * getMD5(const char * md5_msg) override { strcpy_P(md5_msg, (char *)tf2_msgs_FrameGraphResponse_md5);return md5_msg; };
+    virtual const char * getType(const char * type_msg) override { strcpy_P((char *)type_msg, (char *)FRAMEGRAPH);return type_msg; };
+    virtual const char * getMD5(const char * md5_msg) override { strcpy_P((char *)md5_msg, (char *)tf2_msgs_FrameGraphResponse_md5);return md5_msg; };
 
   };
 

--- a/src/tf2_msgs/LookupTransformAction.h
+++ b/src/tf2_msgs/LookupTransformAction.h
@@ -49,8 +49,8 @@ namespace tf2_msgs
      return offset;
     }
 
-    virtual const char * getType(const char * type_msg) override { strcpy_P(type_msg, (char *)tf2_msgs_LookupTransformAction_type);return type_msg; };
-    virtual const char * getMD5(const char * md5_msg) override { strcpy_P(md5_msg, (char *)tf2_msgs_LookupTransformAction_md5);return md5_msg; };
+    virtual const char * getType(const char * type_msg) override { strcpy_P((char *)type_msg, (char *)tf2_msgs_LookupTransformAction_type);return type_msg; };
+    virtual const char * getMD5(const char * md5_msg) override { strcpy_P((char *)md5_msg, (char *)tf2_msgs_LookupTransformAction_md5);return md5_msg; };
 
   };
 

--- a/src/tf2_msgs/LookupTransformActionFeedback.h
+++ b/src/tf2_msgs/LookupTransformActionFeedback.h
@@ -49,8 +49,8 @@ namespace tf2_msgs
      return offset;
     }
 
-    virtual const char * getType(const char * type_msg) override { strcpy_P(type_msg, (char *)tf2_msgs_LookupTransformActionFeedback_type);return type_msg; };
-    virtual const char * getMD5(const char * md5_msg) override { strcpy_P(md5_msg, (char *)tf2_msgs_LookupTransformActionFeedback_md5);return md5_msg; };
+    virtual const char * getType(const char * type_msg) override { strcpy_P((char *)type_msg, (char *)tf2_msgs_LookupTransformActionFeedback_type);return type_msg; };
+    virtual const char * getMD5(const char * md5_msg) override { strcpy_P((char *)md5_msg, (char *)tf2_msgs_LookupTransformActionFeedback_md5);return md5_msg; };
 
   };
 

--- a/src/tf2_msgs/LookupTransformActionGoal.h
+++ b/src/tf2_msgs/LookupTransformActionGoal.h
@@ -49,8 +49,8 @@ namespace tf2_msgs
      return offset;
     }
 
-    virtual const char * getType(const char * type_msg) override { strcpy_P(type_msg, (char *)tf2_msgs_LookupTransformActionGoal_type);return type_msg; };
-    virtual const char * getMD5(const char * md5_msg) override { strcpy_P(md5_msg, (char *)tf2_msgs_LookupTransformActionGoal_md5);return md5_msg; };
+    virtual const char * getType(const char * type_msg) override { strcpy_P((char *)type_msg, (char *)tf2_msgs_LookupTransformActionGoal_type);return type_msg; };
+    virtual const char * getMD5(const char * md5_msg) override { strcpy_P((char *)md5_msg, (char *)tf2_msgs_LookupTransformActionGoal_md5);return md5_msg; };
 
   };
 

--- a/src/tf2_msgs/LookupTransformActionResult.h
+++ b/src/tf2_msgs/LookupTransformActionResult.h
@@ -49,8 +49,8 @@ namespace tf2_msgs
      return offset;
     }
 
-    virtual const char * getType(const char * type_msg) override { strcpy_P(type_msg, (char *)tf2_msgs_LookupTransformActionResult_type);return type_msg; };
-    virtual const char * getMD5(const char * md5_msg) override { strcpy_P(md5_msg, (char *)tf2_msgs_LookupTransformActionResult_md5);return md5_msg; };
+    virtual const char * getType(const char * type_msg) override { strcpy_P((char *)type_msg, (char *)tf2_msgs_LookupTransformActionResult_type);return type_msg; };
+    virtual const char * getMD5(const char * md5_msg) override { strcpy_P((char *)md5_msg, (char *)tf2_msgs_LookupTransformActionResult_md5);return md5_msg; };
 
   };
 

--- a/src/tf2_msgs/LookupTransformFeedback.h
+++ b/src/tf2_msgs/LookupTransformFeedback.h
@@ -31,8 +31,8 @@ namespace tf2_msgs
      return offset;
     }
 
-    virtual const char * getType(const char * type_msg) override { strcpy_P(type_msg, (char *)tf2_msgs_LookupTransformFeedback_type);return type_msg; };
-    virtual const char * getMD5(const char * md5_msg) override { strcpy_P(md5_msg, (char *)tf2_msgs_LookupTransformFeedback_md5);return md5_msg; };
+    virtual const char * getType(const char * type_msg) override { strcpy_P((char *)type_msg, (char *)tf2_msgs_LookupTransformFeedback_type);return type_msg; };
+    virtual const char * getMD5(const char * md5_msg) override { strcpy_P((char *)md5_msg, (char *)tf2_msgs_LookupTransformFeedback_md5);return md5_msg; };
 
   };
 

--- a/src/tf2_msgs/LookupTransformGoal.h
+++ b/src/tf2_msgs/LookupTransformGoal.h
@@ -171,8 +171,8 @@ namespace tf2_msgs
      return offset;
     }
 
-    virtual const char * getType(const char * type_msg) override { strcpy_P(type_msg, (char *)tf2_msgs_LookupTransformGoal_type);return type_msg; };
-    virtual const char * getMD5(const char * md5_msg) override { strcpy_P(md5_msg, (char *)tf2_msgs_LookupTransformGoal_md5);return md5_msg; };
+    virtual const char * getType(const char * type_msg) override { strcpy_P((char *)type_msg, (char *)tf2_msgs_LookupTransformGoal_type);return type_msg; };
+    virtual const char * getMD5(const char * md5_msg) override { strcpy_P((char *)md5_msg, (char *)tf2_msgs_LookupTransformGoal_md5);return md5_msg; };
 
   };
 

--- a/src/tf2_msgs/LookupTransformResult.h
+++ b/src/tf2_msgs/LookupTransformResult.h
@@ -43,8 +43,8 @@ namespace tf2_msgs
      return offset;
     }
 
-    virtual const char * getType(const char * type_msg) override { strcpy_P(type_msg, (char *)tf2_msgs_LookupTransformResult_type);return type_msg; };
-    virtual const char * getMD5(const char * md5_msg) override { strcpy_P(md5_msg, (char *)tf2_msgs_LookupTransformResult_md5);return md5_msg; };
+    virtual const char * getType(const char * type_msg) override { strcpy_P((char *)type_msg, (char *)tf2_msgs_LookupTransformResult_type);return type_msg; };
+    virtual const char * getMD5(const char * md5_msg) override { strcpy_P((char *)md5_msg, (char *)tf2_msgs_LookupTransformResult_md5);return md5_msg; };
 
   };
 

--- a/src/tf2_msgs/TF2Error.h
+++ b/src/tf2_msgs/TF2Error.h
@@ -62,8 +62,8 @@ namespace tf2_msgs
      return offset;
     }
 
-    virtual const char * getType(const char * type_msg) override { strcpy_P(type_msg, (char *)tf2_msgs_TF2Error_type);return type_msg; };
-    virtual const char * getMD5(const char * md5_msg) override { strcpy_P(md5_msg, (char *)tf2_msgs_TF2Error_md5);return md5_msg; };
+    virtual const char * getType(const char * type_msg) override { strcpy_P((char *)type_msg, (char *)tf2_msgs_TF2Error_type);return type_msg; };
+    virtual const char * getMD5(const char * md5_msg) override { strcpy_P((char *)md5_msg, (char *)tf2_msgs_TF2Error_md5);return md5_msg; };
 
   };
 

--- a/src/tf2_msgs/TFMessage.h
+++ b/src/tf2_msgs/TFMessage.h
@@ -57,8 +57,8 @@ namespace tf2_msgs
      return offset;
     }
 
-    virtual const char * getType(const char * type_msg) override { strcpy_P(type_msg, (char *)tf2_msgs_TFMessage_type);return type_msg; };
-    virtual const char * getMD5(const char * md5_msg) override { strcpy_P(md5_msg, (char *)tf2_msgs_TFMessage_md5);return md5_msg; };
+    virtual const char * getType(const char * type_msg) override { strcpy_P((char *)type_msg, (char *)tf2_msgs_TFMessage_type);return type_msg; };
+    virtual const char * getMD5(const char * md5_msg) override { strcpy_P((char *)md5_msg, (char *)tf2_msgs_TFMessage_md5);return md5_msg; };
 
   };
 

--- a/src/topic_tools/DemuxAdd.h
+++ b/src/topic_tools/DemuxAdd.h
@@ -49,8 +49,8 @@ static const char DEMUXADD[] PROGMEM= "topic_tools/DemuxAdd";
      return offset;
     }
 
-    virtual const char * getType(const char * type_msg) override { strcpy_P(type_msg, (char *)DEMUXADD);return type_msg; };
-    virtual const char * getMD5(const char * md5_msg) override { strcpy_P(md5_msg, (char *)topic_tools_DemuxAddRequest_md5);return md5_msg; };
+    virtual const char * getType(const char * type_msg) override { strcpy_P((char *)type_msg, (char *)DEMUXADD);return type_msg; };
+    virtual const char * getMD5(const char * md5_msg) override { strcpy_P((char *)md5_msg, (char *)topic_tools_DemuxAddRequest_md5);return md5_msg; };
 
   };
 
@@ -76,8 +76,8 @@ static const char DEMUXADD[] PROGMEM= "topic_tools/DemuxAdd";
      return offset;
     }
 
-    virtual const char * getType(const char * type_msg) override { strcpy_P(type_msg, (char *)DEMUXADD);return type_msg; };
-    virtual const char * getMD5(const char * md5_msg) override { strcpy_P(md5_msg, (char *)topic_tools_DemuxAddResponse_md5);return md5_msg; };
+    virtual const char * getType(const char * type_msg) override { strcpy_P((char *)type_msg, (char *)DEMUXADD);return type_msg; };
+    virtual const char * getMD5(const char * md5_msg) override { strcpy_P((char *)md5_msg, (char *)topic_tools_DemuxAddResponse_md5);return md5_msg; };
 
   };
 

--- a/src/topic_tools/DemuxDelete.h
+++ b/src/topic_tools/DemuxDelete.h
@@ -49,8 +49,8 @@ static const char DEMUXDELETE[] PROGMEM= "topic_tools/DemuxDelete";
      return offset;
     }
 
-    virtual const char * getType(const char * type_msg) override { strcpy_P(type_msg, (char *)DEMUXDELETE);return type_msg; };
-    virtual const char * getMD5(const char * md5_msg) override { strcpy_P(md5_msg, (char *)topic_tools_DemuxDeleteRequest_md5);return md5_msg; };
+    virtual const char * getType(const char * type_msg) override { strcpy_P((char *)type_msg, (char *)DEMUXDELETE);return type_msg; };
+    virtual const char * getMD5(const char * md5_msg) override { strcpy_P((char *)md5_msg, (char *)topic_tools_DemuxDeleteRequest_md5);return md5_msg; };
 
   };
 
@@ -76,8 +76,8 @@ static const char DEMUXDELETE[] PROGMEM= "topic_tools/DemuxDelete";
      return offset;
     }
 
-    virtual const char * getType(const char * type_msg) override { strcpy_P(type_msg, (char *)DEMUXDELETE);return type_msg; };
-    virtual const char * getMD5(const char * md5_msg) override { strcpy_P(md5_msg, (char *)topic_tools_DemuxDeleteResponse_md5);return md5_msg; };
+    virtual const char * getType(const char * type_msg) override { strcpy_P((char *)type_msg, (char *)DEMUXDELETE);return type_msg; };
+    virtual const char * getMD5(const char * md5_msg) override { strcpy_P((char *)md5_msg, (char *)topic_tools_DemuxDeleteResponse_md5);return md5_msg; };
 
   };
 

--- a/src/topic_tools/DemuxList.h
+++ b/src/topic_tools/DemuxList.h
@@ -32,8 +32,8 @@ static const char DEMUXLIST[] PROGMEM= "topic_tools/DemuxList";
      return offset;
     }
 
-    virtual const char * getType(const char * type_msg) override { strcpy_P(type_msg, (char *)DEMUXLIST);return type_msg; };
-    virtual const char * getMD5(const char * md5_msg) override { strcpy_P(md5_msg, (char *)topic_tools_DemuxListRequest_md5);return md5_msg; };
+    virtual const char * getType(const char * type_msg) override { strcpy_P((char *)type_msg, (char *)DEMUXLIST);return type_msg; };
+    virtual const char * getMD5(const char * md5_msg) override { strcpy_P((char *)md5_msg, (char *)topic_tools_DemuxListRequest_md5);return md5_msg; };
 
   };
 
@@ -96,8 +96,8 @@ static const char DEMUXLIST[] PROGMEM= "topic_tools/DemuxList";
      return offset;
     }
 
-    virtual const char * getType(const char * type_msg) override { strcpy_P(type_msg, (char *)DEMUXLIST);return type_msg; };
-    virtual const char * getMD5(const char * md5_msg) override { strcpy_P(md5_msg, (char *)topic_tools_DemuxListResponse_md5);return md5_msg; };
+    virtual const char * getType(const char * type_msg) override { strcpy_P((char *)type_msg, (char *)DEMUXLIST);return type_msg; };
+    virtual const char * getMD5(const char * md5_msg) override { strcpy_P((char *)md5_msg, (char *)topic_tools_DemuxListResponse_md5);return md5_msg; };
 
   };
 

--- a/src/topic_tools/DemuxSelect.h
+++ b/src/topic_tools/DemuxSelect.h
@@ -49,8 +49,8 @@ static const char DEMUXSELECT[] PROGMEM= "topic_tools/DemuxSelect";
      return offset;
     }
 
-    virtual const char * getType(const char * type_msg) override { strcpy_P(type_msg, (char *)DEMUXSELECT);return type_msg; };
-    virtual const char * getMD5(const char * md5_msg) override { strcpy_P(md5_msg, (char *)topic_tools_DemuxSelectRequest_md5);return md5_msg; };
+    virtual const char * getType(const char * type_msg) override { strcpy_P((char *)type_msg, (char *)DEMUXSELECT);return type_msg; };
+    virtual const char * getMD5(const char * md5_msg) override { strcpy_P((char *)md5_msg, (char *)topic_tools_DemuxSelectRequest_md5);return md5_msg; };
 
   };
 
@@ -93,8 +93,8 @@ static const char DEMUXSELECT[] PROGMEM= "topic_tools/DemuxSelect";
      return offset;
     }
 
-    virtual const char * getType(const char * type_msg) override { strcpy_P(type_msg, (char *)DEMUXSELECT);return type_msg; };
-    virtual const char * getMD5(const char * md5_msg) override { strcpy_P(md5_msg, (char *)topic_tools_DemuxSelectResponse_md5);return md5_msg; };
+    virtual const char * getType(const char * type_msg) override { strcpy_P((char *)type_msg, (char *)DEMUXSELECT);return type_msg; };
+    virtual const char * getMD5(const char * md5_msg) override { strcpy_P((char *)md5_msg, (char *)topic_tools_DemuxSelectResponse_md5);return md5_msg; };
 
   };
 

--- a/src/topic_tools/MuxAdd.h
+++ b/src/topic_tools/MuxAdd.h
@@ -49,8 +49,8 @@ static const char MUXADD[] PROGMEM= "topic_tools/MuxAdd";
      return offset;
     }
 
-    virtual const char * getType(const char * type_msg) override { strcpy_P(type_msg, (char *)MUXADD);return type_msg; };
-    virtual const char * getMD5(const char * md5_msg) override { strcpy_P(md5_msg, (char *)topic_tools_MuxAddRequest_md5);return md5_msg; };
+    virtual const char * getType(const char * type_msg) override { strcpy_P((char *)type_msg, (char *)MUXADD);return type_msg; };
+    virtual const char * getMD5(const char * md5_msg) override { strcpy_P((char *)md5_msg, (char *)topic_tools_MuxAddRequest_md5);return md5_msg; };
 
   };
 
@@ -76,8 +76,8 @@ static const char MUXADD[] PROGMEM= "topic_tools/MuxAdd";
      return offset;
     }
 
-    virtual const char * getType(const char * type_msg) override { strcpy_P(type_msg, (char *)MUXADD);return type_msg; };
-    virtual const char * getMD5(const char * md5_msg) override { strcpy_P(md5_msg, (char *)topic_tools_MuxAddResponse_md5);return md5_msg; };
+    virtual const char * getType(const char * type_msg) override { strcpy_P((char *)type_msg, (char *)MUXADD);return type_msg; };
+    virtual const char * getMD5(const char * md5_msg) override { strcpy_P((char *)md5_msg, (char *)topic_tools_MuxAddResponse_md5);return md5_msg; };
 
   };
 

--- a/src/topic_tools/MuxDelete.h
+++ b/src/topic_tools/MuxDelete.h
@@ -49,8 +49,8 @@ static const char MUXDELETE[] PROGMEM= "topic_tools/MuxDelete";
      return offset;
     }
 
-    virtual const char * getType(const char * type_msg) override { strcpy_P(type_msg, (char *)MUXDELETE);return type_msg; };
-    virtual const char * getMD5(const char * md5_msg) override { strcpy_P(md5_msg, (char *)topic_tools_MuxDeleteRequest_md5);return md5_msg; };
+    virtual const char * getType(const char * type_msg) override { strcpy_P((char *)type_msg, (char *)MUXDELETE);return type_msg; };
+    virtual const char * getMD5(const char * md5_msg) override { strcpy_P((char *)md5_msg, (char *)topic_tools_MuxDeleteRequest_md5);return md5_msg; };
 
   };
 
@@ -76,8 +76,8 @@ static const char MUXDELETE[] PROGMEM= "topic_tools/MuxDelete";
      return offset;
     }
 
-    virtual const char * getType(const char * type_msg) override { strcpy_P(type_msg, (char *)MUXDELETE);return type_msg; };
-    virtual const char * getMD5(const char * md5_msg) override { strcpy_P(md5_msg, (char *)topic_tools_MuxDeleteResponse_md5);return md5_msg; };
+    virtual const char * getType(const char * type_msg) override { strcpy_P((char *)type_msg, (char *)MUXDELETE);return type_msg; };
+    virtual const char * getMD5(const char * md5_msg) override { strcpy_P((char *)md5_msg, (char *)topic_tools_MuxDeleteResponse_md5);return md5_msg; };
 
   };
 

--- a/src/topic_tools/MuxList.h
+++ b/src/topic_tools/MuxList.h
@@ -32,8 +32,8 @@ static const char MUXLIST[] PROGMEM= "topic_tools/MuxList";
      return offset;
     }
 
-    virtual const char * getType(const char * type_msg) override { strcpy_P(type_msg, (char *)MUXLIST);return type_msg; };
-    virtual const char * getMD5(const char * md5_msg) override { strcpy_P(md5_msg, (char *)topic_tools_MuxListRequest_md5);return md5_msg; };
+    virtual const char * getType(const char * type_msg) override { strcpy_P((char *)type_msg, (char *)MUXLIST);return type_msg; };
+    virtual const char * getMD5(const char * md5_msg) override { strcpy_P((char *)md5_msg, (char *)topic_tools_MuxListRequest_md5);return md5_msg; };
 
   };
 
@@ -96,8 +96,8 @@ static const char MUXLIST[] PROGMEM= "topic_tools/MuxList";
      return offset;
     }
 
-    virtual const char * getType(const char * type_msg) override { strcpy_P(type_msg, (char *)MUXLIST);return type_msg; };
-    virtual const char * getMD5(const char * md5_msg) override { strcpy_P(md5_msg, (char *)topic_tools_MuxListResponse_md5);return md5_msg; };
+    virtual const char * getType(const char * type_msg) override { strcpy_P((char *)type_msg, (char *)MUXLIST);return type_msg; };
+    virtual const char * getMD5(const char * md5_msg) override { strcpy_P((char *)md5_msg, (char *)topic_tools_MuxListResponse_md5);return md5_msg; };
 
   };
 

--- a/src/topic_tools/MuxSelect.h
+++ b/src/topic_tools/MuxSelect.h
@@ -49,8 +49,8 @@ static const char MUXSELECT[] PROGMEM= "topic_tools/MuxSelect";
      return offset;
     }
 
-    virtual const char * getType(const char * type_msg) override { strcpy_P(type_msg, (char *)MUXSELECT);return type_msg; };
-    virtual const char * getMD5(const char * md5_msg) override { strcpy_P(md5_msg, (char *)topic_tools_MuxSelectRequest_md5);return md5_msg; };
+    virtual const char * getType(const char * type_msg) override { strcpy_P((char *)type_msg, (char *)MUXSELECT);return type_msg; };
+    virtual const char * getMD5(const char * md5_msg) override { strcpy_P((char *)md5_msg, (char *)topic_tools_MuxSelectRequest_md5);return md5_msg; };
 
   };
 
@@ -93,8 +93,8 @@ static const char MUXSELECT[] PROGMEM= "topic_tools/MuxSelect";
      return offset;
     }
 
-    virtual const char * getType(const char * type_msg) override { strcpy_P(type_msg, (char *)MUXSELECT);return type_msg; };
-    virtual const char * getMD5(const char * md5_msg) override { strcpy_P(md5_msg, (char *)topic_tools_MuxSelectResponse_md5);return md5_msg; };
+    virtual const char * getType(const char * type_msg) override { strcpy_P((char *)type_msg, (char *)MUXSELECT);return type_msg; };
+    virtual const char * getMD5(const char * md5_msg) override { strcpy_P((char *)md5_msg, (char *)topic_tools_MuxSelectResponse_md5);return md5_msg; };
 
   };
 

--- a/src/trajectory_msgs/JointTrajectory.h
+++ b/src/trajectory_msgs/JointTrajectory.h
@@ -100,8 +100,8 @@ namespace trajectory_msgs
      return offset;
     }
 
-    virtual const char * getType(const char * type_msg) override { strcpy_P(type_msg, (char *)trajectory_msgs_JointTrajectory_type);return type_msg; };
-    virtual const char * getMD5(const char * md5_msg) override { strcpy_P(md5_msg, (char *)trajectory_msgs_JointTrajectory_md5);return md5_msg; };
+    virtual const char * getType(const char * type_msg) override { strcpy_P((char *)type_msg, (char *)trajectory_msgs_JointTrajectory_type);return type_msg; };
+    virtual const char * getMD5(const char * md5_msg) override { strcpy_P((char *)md5_msg, (char *)trajectory_msgs_JointTrajectory_md5);return md5_msg; };
 
   };
 

--- a/src/trajectory_msgs/JointTrajectoryPoint.h
+++ b/src/trajectory_msgs/JointTrajectoryPoint.h
@@ -155,8 +155,8 @@ namespace trajectory_msgs
      return offset;
     }
 
-    virtual const char * getType(const char * type_msg) override { strcpy_P(type_msg, (char *)trajectory_msgs_JointTrajectoryPoint_type);return type_msg; };
-    virtual const char * getMD5(const char * md5_msg) override { strcpy_P(md5_msg, (char *)trajectory_msgs_JointTrajectoryPoint_md5);return md5_msg; };
+    virtual const char * getType(const char * type_msg) override { strcpy_P((char *)type_msg, (char *)trajectory_msgs_JointTrajectoryPoint_type);return type_msg; };
+    virtual const char * getMD5(const char * md5_msg) override { strcpy_P((char *)md5_msg, (char *)trajectory_msgs_JointTrajectoryPoint_md5);return md5_msg; };
 
   };
 

--- a/src/trajectory_msgs/MultiDOFJointTrajectory.h
+++ b/src/trajectory_msgs/MultiDOFJointTrajectory.h
@@ -100,8 +100,8 @@ namespace trajectory_msgs
      return offset;
     }
 
-    virtual const char * getType(const char * type_msg) override { strcpy_P(type_msg, (char *)trajectory_msgs_MultiDOFJointTrajectory_type);return type_msg; };
-    virtual const char * getMD5(const char * md5_msg) override { strcpy_P(md5_msg, (char *)trajectory_msgs_MultiDOFJointTrajectory_md5);return md5_msg; };
+    virtual const char * getType(const char * type_msg) override { strcpy_P((char *)type_msg, (char *)trajectory_msgs_MultiDOFJointTrajectory_type);return type_msg; };
+    virtual const char * getMD5(const char * md5_msg) override { strcpy_P((char *)md5_msg, (char *)trajectory_msgs_MultiDOFJointTrajectory_md5);return md5_msg; };
 
   };
 

--- a/src/trajectory_msgs/MultiDOFJointTrajectoryPoint.h
+++ b/src/trajectory_msgs/MultiDOFJointTrajectoryPoint.h
@@ -132,8 +132,8 @@ namespace trajectory_msgs
      return offset;
     }
 
-    virtual const char * getType(const char * type_msg) override { strcpy_P(type_msg, (char *)trajectory_msgs_MultiDOFJointTrajectoryPoint_type);return type_msg; };
-    virtual const char * getMD5(const char * md5_msg) override { strcpy_P(md5_msg, (char *)trajectory_msgs_MultiDOFJointTrajectoryPoint_md5);return md5_msg; };
+    virtual const char * getType(const char * type_msg) override { strcpy_P((char *)type_msg, (char *)trajectory_msgs_MultiDOFJointTrajectoryPoint_type);return type_msg; };
+    virtual const char * getMD5(const char * md5_msg) override { strcpy_P((char *)md5_msg, (char *)trajectory_msgs_MultiDOFJointTrajectoryPoint_md5);return md5_msg; };
 
   };
 

--- a/src/visualization_msgs/ImageMarker.h
+++ b/src/visualization_msgs/ImageMarker.h
@@ -255,8 +255,8 @@ namespace visualization_msgs
      return offset;
     }
 
-    virtual const char * getType(const char * type_msg) override { strcpy_P(type_msg, (char *)visualization_msgs_ImageMarker_type);return type_msg; };
-    virtual const char * getMD5(const char * md5_msg) override { strcpy_P(md5_msg, (char *)visualization_msgs_ImageMarker_md5);return md5_msg; };
+    virtual const char * getType(const char * type_msg) override { strcpy_P((char *)type_msg, (char *)visualization_msgs_ImageMarker_type);return type_msg; };
+    virtual const char * getMD5(const char * md5_msg) override { strcpy_P((char *)md5_msg, (char *)visualization_msgs_ImageMarker_md5);return md5_msg; };
 
   };
 

--- a/src/visualization_msgs/InteractiveMarker.h
+++ b/src/visualization_msgs/InteractiveMarker.h
@@ -153,8 +153,8 @@ namespace visualization_msgs
      return offset;
     }
 
-    virtual const char * getType(const char * type_msg) override { strcpy_P(type_msg, (char *)visualization_msgs_InteractiveMarker_type);return type_msg; };
-    virtual const char * getMD5(const char * md5_msg) override { strcpy_P(md5_msg, (char *)visualization_msgs_InteractiveMarker_md5);return md5_msg; };
+    virtual const char * getType(const char * type_msg) override { strcpy_P((char *)type_msg, (char *)visualization_msgs_InteractiveMarker_type);return type_msg; };
+    virtual const char * getMD5(const char * md5_msg) override { strcpy_P((char *)md5_msg, (char *)visualization_msgs_InteractiveMarker_md5);return md5_msg; };
 
   };
 

--- a/src/visualization_msgs/InteractiveMarkerControl.h
+++ b/src/visualization_msgs/InteractiveMarkerControl.h
@@ -160,8 +160,8 @@ namespace visualization_msgs
      return offset;
     }
 
-    virtual const char * getType(const char * type_msg) override { strcpy_P(type_msg, (char *)visualization_msgs_InteractiveMarkerControl_type);return type_msg; };
-    virtual const char * getMD5(const char * md5_msg) override { strcpy_P(md5_msg, (char *)visualization_msgs_InteractiveMarkerControl_md5);return md5_msg; };
+    virtual const char * getType(const char * type_msg) override { strcpy_P((char *)type_msg, (char *)visualization_msgs_InteractiveMarkerControl_type);return type_msg; };
+    virtual const char * getMD5(const char * md5_msg) override { strcpy_P((char *)md5_msg, (char *)visualization_msgs_InteractiveMarkerControl_md5);return md5_msg; };
 
   };
 

--- a/src/visualization_msgs/InteractiveMarkerFeedback.h
+++ b/src/visualization_msgs/InteractiveMarkerFeedback.h
@@ -144,8 +144,8 @@ namespace visualization_msgs
      return offset;
     }
 
-    virtual const char * getType(const char * type_msg) override { strcpy_P(type_msg, (char *)visualization_msgs_InteractiveMarkerFeedback_type);return type_msg; };
-    virtual const char * getMD5(const char * md5_msg) override { strcpy_P(md5_msg, (char *)visualization_msgs_InteractiveMarkerFeedback_md5);return md5_msg; };
+    virtual const char * getType(const char * type_msg) override { strcpy_P((char *)type_msg, (char *)visualization_msgs_InteractiveMarkerFeedback_type);return type_msg; };
+    virtual const char * getMD5(const char * md5_msg) override { strcpy_P((char *)md5_msg, (char *)visualization_msgs_InteractiveMarkerFeedback_md5);return md5_msg; };
 
   };
 

--- a/src/visualization_msgs/InteractiveMarkerInit.h
+++ b/src/visualization_msgs/InteractiveMarkerInit.h
@@ -95,8 +95,8 @@ namespace visualization_msgs
      return offset;
     }
 
-    virtual const char * getType(const char * type_msg) override { strcpy_P(type_msg, (char *)visualization_msgs_InteractiveMarkerInit_type);return type_msg; };
-    virtual const char * getMD5(const char * md5_msg) override { strcpy_P(md5_msg, (char *)visualization_msgs_InteractiveMarkerInit_md5);return md5_msg; };
+    virtual const char * getType(const char * type_msg) override { strcpy_P((char *)type_msg, (char *)visualization_msgs_InteractiveMarkerInit_type);return type_msg; };
+    virtual const char * getMD5(const char * md5_msg) override { strcpy_P((char *)md5_msg, (char *)visualization_msgs_InteractiveMarkerInit_md5);return md5_msg; };
 
   };
 

--- a/src/visualization_msgs/InteractiveMarkerPose.h
+++ b/src/visualization_msgs/InteractiveMarkerPose.h
@@ -60,8 +60,8 @@ namespace visualization_msgs
      return offset;
     }
 
-    virtual const char * getType(const char * type_msg) override { strcpy_P(type_msg, (char *)visualization_msgs_InteractiveMarkerPose_type);return type_msg; };
-    virtual const char * getMD5(const char * md5_msg) override { strcpy_P(md5_msg, (char *)visualization_msgs_InteractiveMarkerPose_md5);return md5_msg; };
+    virtual const char * getType(const char * type_msg) override { strcpy_P((char *)type_msg, (char *)visualization_msgs_InteractiveMarkerPose_type);return type_msg; };
+    virtual const char * getMD5(const char * md5_msg) override { strcpy_P((char *)md5_msg, (char *)visualization_msgs_InteractiveMarkerPose_md5);return md5_msg; };
 
   };
 

--- a/src/visualization_msgs/InteractiveMarkerUpdate.h
+++ b/src/visualization_msgs/InteractiveMarkerUpdate.h
@@ -167,8 +167,8 @@ namespace visualization_msgs
      return offset;
     }
 
-    virtual const char * getType(const char * type_msg) override { strcpy_P(type_msg, (char *)visualization_msgs_InteractiveMarkerUpdate_type);return type_msg; };
-    virtual const char * getMD5(const char * md5_msg) override { strcpy_P(md5_msg, (char *)visualization_msgs_InteractiveMarkerUpdate_md5);return md5_msg; };
+    virtual const char * getType(const char * type_msg) override { strcpy_P((char *)type_msg, (char *)visualization_msgs_InteractiveMarkerUpdate_type);return type_msg; };
+    virtual const char * getMD5(const char * md5_msg) override { strcpy_P((char *)md5_msg, (char *)visualization_msgs_InteractiveMarkerUpdate_md5);return md5_msg; };
 
   };
 

--- a/src/visualization_msgs/Marker.h
+++ b/src/visualization_msgs/Marker.h
@@ -305,8 +305,8 @@ namespace visualization_msgs
      return offset;
     }
 
-    virtual const char * getType(const char * type_msg) override { strcpy_P(type_msg, (char *)visualization_msgs_Marker_type);return type_msg; };
-    virtual const char * getMD5(const char * md5_msg) override { strcpy_P(md5_msg, (char *)visualization_msgs_Marker_md5);return md5_msg; };
+    virtual const char * getType(const char * type_msg) override { strcpy_P((char *)type_msg, (char *)visualization_msgs_Marker_type);return type_msg; };
+    virtual const char * getMD5(const char * md5_msg) override { strcpy_P((char *)md5_msg, (char *)visualization_msgs_Marker_md5);return md5_msg; };
 
   };
 

--- a/src/visualization_msgs/MarkerArray.h
+++ b/src/visualization_msgs/MarkerArray.h
@@ -57,8 +57,8 @@ namespace visualization_msgs
      return offset;
     }
 
-    virtual const char * getType(const char * type_msg) override { strcpy_P(type_msg, (char *)visualization_msgs_MarkerArray_type);return type_msg; };
-    virtual const char * getMD5(const char * md5_msg) override { strcpy_P(md5_msg, (char *)visualization_msgs_MarkerArray_md5);return md5_msg; };
+    virtual const char * getType(const char * type_msg) override { strcpy_P((char *)type_msg, (char *)visualization_msgs_MarkerArray_type);return type_msg; };
+    virtual const char * getMD5(const char * md5_msg) override { strcpy_P((char *)md5_msg, (char *)visualization_msgs_MarkerArray_md5);return md5_msg; };
 
   };
 

--- a/src/visualization_msgs/MenuEntry.h
+++ b/src/visualization_msgs/MenuEntry.h
@@ -101,8 +101,8 @@ namespace visualization_msgs
      return offset;
     }
 
-    virtual const char * getType(const char * type_msg) override { strcpy_P(type_msg, (char *)visualization_msgs_MenuEntry_type);return type_msg; };
-    virtual const char * getMD5(const char * md5_msg) override { strcpy_P(md5_msg, (char *)visualization_msgs_MenuEntry_md5);return md5_msg; };
+    virtual const char * getType(const char * type_msg) override { strcpy_P((char *)type_msg, (char *)visualization_msgs_MenuEntry_type);return type_msg; };
+    virtual const char * getMD5(const char * md5_msg) override { strcpy_P((char *)md5_msg, (char *)visualization_msgs_MenuEntry_md5);return md5_msg; };
 
   };
 


### PR DESCRIPTION
Made a breaking API change that allows for developers with EPS32 based devices to use UART to communicate with ROS core. To enable TCP based communication, `#define ROSSERIAL_ARDUINO_TCP 1` must be defined in the user's code. By default, for ESP32 based devices, UART is the default communication mode.